### PR TITLE
feat: add MCP server for AI coding agent integration

### DIFF
--- a/README-MCP.md
+++ b/README-MCP.md
@@ -1,0 +1,370 @@
+# markupr MCP Server
+
+Give your AI coding agent eyes and ears. The markupr MCP server lets Claude Code, Cursor, and Windsurf capture screenshots and screen recordings with voice narration -- then processes everything into structured, AI-ready Markdown reports.
+
+**Version:** 2.3.0 | **Platform:** macOS | **Protocol:** MCP (Model Context Protocol) over stdio
+
+---
+
+## Prerequisites
+
+- **Node.js 18+**
+- **ffmpeg** -- required for screen recording and frame extraction
+  ```bash
+  brew install ffmpeg
+  ```
+- **macOS permissions:**
+  - **Screen Recording** -- System Settings > Privacy & Security > Screen Recording
+  - **Microphone** -- System Settings > Privacy & Security > Microphone
+
+> The server checks permissions on first use and returns actionable error messages if anything is missing.
+
+---
+
+## Installation
+
+### Zero-install (recommended)
+
+Use `npx` -- no global install needed. Your IDE configuration handles the rest:
+
+```bash
+npx markupr-mcp
+```
+
+### Global install
+
+```bash
+npm install -g markupr
+```
+
+This installs both the `markupr` CLI and the `markupr-mcp` server binary.
+
+---
+
+## IDE Configuration
+
+### Claude Code
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "markupr": {
+      "command": "npx",
+      "args": ["-y", "markupr-mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json` in your project root (or `~/.cursor/mcp.json` globally):
+
+```json
+{
+  "mcpServers": {
+    "markupr": {
+      "command": "npx",
+      "args": ["-y", "markupr-mcp"]
+    }
+  }
+}
+```
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "markupr": {
+      "command": "npx",
+      "args": ["-y", "markupr-mcp"]
+    }
+  }
+}
+```
+
+> A copy-paste config file is available at [`docs/mcp-config-example.json`](docs/mcp-config-example.json).
+
+---
+
+## Tools
+
+The MCP server exposes 6 tools. Your AI agent can call these directly during a conversation.
+
+### `capture_screenshot`
+
+Take a screenshot of the current screen. Returns a markdown image reference saved to the session directory.
+
+**Input:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `label` | string | -- | Optional label for the screenshot |
+| `display` | number | `1` | Display number (1-indexed) |
+| `optimize` | boolean | `true` | Optimize image size with sharp |
+
+**Example:**
+```
+capture_screenshot({ label: "broken navbar", display: 1 })
+```
+
+**Returns:**
+```
+Screenshot saved: /Users/you/Documents/markupr/mcp/session-20260214-143022/screenshot-001.png
+![broken navbar](screenshots/screenshot-001.png)
+```
+
+---
+
+### `capture_with_voice`
+
+Record screen and voice for a fixed duration, then run the full markupr pipeline. Produces a structured Markdown report with transcript, key moments, and extracted frames.
+
+**Input:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `duration` | number | -- | Recording duration in seconds (3-300) |
+| `outputDir` | string | `~/Documents/markupr/mcp/` | Output directory |
+| `skipFrames` | boolean | `false` | Skip frame extraction |
+
+**Example:**
+```
+capture_with_voice({ duration: 30 })
+```
+
+**Returns:**
+```
+Recording complete: 30 seconds captured
+Pipeline results:
+  Transcript segments: 12
+  Extracted frames: 4
+  Processing time: 8.2s
+
+Report: /Users/you/Documents/markupr/mcp/session-20260214-143022/feedback-report.md
+```
+
+---
+
+### `analyze_video`
+
+Process an existing video file through the markupr pipeline. Useful for recordings made outside markupr.
+
+**Input:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `videoPath` | string | -- | Absolute path to the video file |
+| `audioPath` | string | -- | Separate audio file (if not embedded) |
+| `outputDir` | string | `~/Documents/markupr/mcp/` | Output directory |
+| `skipFrames` | boolean | `false` | Skip frame extraction |
+
+**Example:**
+```
+analyze_video({ videoPath: "/Users/you/Desktop/bug-demo.mov" })
+```
+
+**Returns:** Same format as `capture_with_voice` -- report path and summary.
+
+---
+
+### `analyze_screenshot`
+
+Take a screenshot and return it as image data for the AI to analyze visually. Unlike `capture_screenshot`, this returns the image directly for vision analysis rather than saving a reference.
+
+**Input:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `display` | number | `1` | Display number (1-indexed) |
+| `question` | string | -- | What to look for in the screenshot |
+
+**Example:**
+```
+analyze_screenshot({ question: "Is the sidebar overlapping the main content?" })
+```
+
+**Returns:** Image data (base64 PNG) that the AI can see and analyze, plus a text description with the capture timestamp.
+
+---
+
+### `start_recording`
+
+Begin a long-form screen and voice recording session. Returns a session ID for use with `stop_recording`. Only one recording can be active at a time.
+
+**Input:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `label` | string | -- | Session label for organization |
+
+**Example:**
+```
+start_recording({ label: "onboarding review" })
+```
+
+**Returns:**
+```
+Recording started.
+Session ID: mcp-20260214-143022
+Status: recording
+Use stop_recording to end and process the recording.
+```
+
+---
+
+### `stop_recording`
+
+Stop an active recording and run the full markupr pipeline on the captured video.
+
+**Input:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `sessionId` | string | current | Session ID (defaults to the active recording) |
+| `skipFrames` | boolean | `false` | Skip frame extraction |
+
+**Example:**
+```
+stop_recording({})
+```
+
+**Returns:** Same format as `capture_with_voice` -- report path and summary.
+
+---
+
+## Resources
+
+The server also exposes MCP resources for querying session data:
+
+| URI | Description |
+|-----|-------------|
+| `session://latest` | Metadata for the most recent session |
+| `session://{id}` | Metadata for a specific session by ID |
+
+---
+
+## How It Works
+
+1. **Your AI agent calls a tool** -- e.g., `capture_with_voice({ duration: 30 })`
+2. **markupr captures** -- records screen and microphone via ffmpeg
+3. **The pipeline runs** -- transcribes audio (Whisper), detects key moments, extracts frames at those timestamps
+4. **Structured output** -- produces a Markdown report with screenshots placed at the exact moments you described them
+5. **Agent reads the report** -- the tool returns the file path; the agent reads and acts on the structured feedback
+
+All processing happens locally. No data leaves your machine unless you configure an OpenAI API key for cloud transcription.
+
+---
+
+## Session Output
+
+Sessions are saved to `~/Documents/markupr/mcp/`:
+
+```
+~/Documents/markupr/mcp/mcp-20260214-143022/
+  feedback-report.md     # Structured Markdown report
+  metadata.json          # Session metadata
+  screenshots/
+    screenshot-001.png   # Extracted frames from key moments
+    screenshot-002.png
+  recording.mp4          # Screen recording (if applicable)
+```
+
+---
+
+## Troubleshooting
+
+### Permission errors
+
+**Screen Recording denied:**
+```
+Error: Screen Recording permission not granted
+```
+Fix: System Settings > Privacy & Security > Screen Recording > enable your terminal app (Terminal, iTerm2, VS Code, etc.)
+
+**Microphone denied:**
+```
+Error: Microphone permission not granted
+```
+Fix: System Settings > Privacy & Security > Microphone > enable your terminal app
+
+> After granting permissions, restart your terminal or IDE for changes to take effect.
+
+### ffmpeg not found
+
+```
+Error: ffmpeg not found on PATH
+```
+Fix:
+```bash
+brew install ffmpeg
+```
+
+Verify installation:
+```bash
+ffmpeg -version
+```
+
+> Screenshot tools (`capture_screenshot`, `analyze_screenshot`) work without ffmpeg. Only recording and video analysis tools require it.
+
+### No audio device detected
+
+```
+Error: No audio input device found
+```
+Fix:
+- Check System Settings > Sound > Input -- ensure a microphone is selected
+- If using an external mic, verify it's connected and recognized
+- Try selecting a specific device in System Settings
+
+### Server not connecting
+
+If your IDE can't connect to the MCP server:
+
+1. **Verify the config** -- check that `"command": "npx"` and `"args": ["-y", "markupr-mcp"]` are correct
+2. **Test manually** -- run `npx markupr-mcp` in a terminal. It should start silently (output goes to stderr)
+3. **Check Node.js version** -- `node --version` should be 18+
+4. **Restart your IDE** after adding or changing MCP configuration
+
+### stdout corruption
+
+The MCP protocol uses stdout for JSON-RPC communication. If you see garbled output:
+- Ensure no other tools are writing to stdout in the same process
+- All markupr logging goes to stderr by design
+
+---
+
+## Development
+
+To develop the MCP server locally:
+
+```bash
+# Clone and install
+git clone https://github.com/eddiesanjuan/markupr.git
+cd markupr
+npm install
+
+# Build the MCP server
+npm run build:mcp
+
+# Test locally
+node dist/mcp/index.mjs
+```
+
+For Claude Code, point to your local build:
+
+```json
+{
+  "mcpServers": {
+    "markupr": {
+      "command": "node",
+      "args": ["/path/to/markupr/dist/mcp/index.mjs"]
+    }
+  }
+}
+```
+
+---
+
+## License
+
+MIT -- see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   <a href="#how-it-works">How It Works</a> |
   <a href="#installation">Installation</a> |
   <a href="#cli-usage">CLI Usage</a> |
+  <a href="#mcp-server-for-ai-coding-agents">MCP Server</a> |
   <a href="#usage">Usage</a> |
   <a href="#keyboard-shortcuts">Shortcuts</a> |
   <a href="#export-formats">Export</a> |
@@ -309,6 +310,25 @@ cat ./feedback/markupr-report.md
 ```
 
 The output Markdown follows the llms.txt convention -- structured, parseable, and optimized for AI consumption.
+
+## MCP Server (for AI Coding Agents)
+
+markupr includes an MCP (Model Context Protocol) server that gives AI coding agents direct access to screen capture and voice recording. Claude Code, Cursor, and Windsurf can call markupr tools during a conversation -- capturing screenshots, recording your screen with voice narration, and receiving structured Markdown reports back.
+
+Add to your IDE config and your agent gets 6 tools: `capture_screenshot`, `capture_with_voice`, `analyze_video`, `analyze_screenshot`, `start_recording`, and `stop_recording`.
+
+```json
+{
+  "mcpServers": {
+    "markupr": {
+      "command": "npx",
+      "args": ["-y", "markupr-mcp"]
+    }
+  }
+}
+```
+
+See **[README-MCP.md](README-MCP.md)** for full setup instructions, tool documentation, and troubleshooting.
 
 ## Usage
 

--- a/docs/mcp-config-example.json
+++ b/docs/mcp-config-example.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "markupr": {
+      "command": "npx",
+      "args": ["-y", "markupr-mcp"]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "commander": "^14.0.3",
         "electron-log": "^5.4.3",
         "electron-store": "^11.0.2",
@@ -18,7 +19,8 @@
         "keytar": "^7.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "whisper-node": "^1.1.1"
+        "whisper-node": "^1.1.1",
+        "zod": "^4.3.6"
       },
       "bin": {
         "markupr": "dist/cli/index.mjs"
@@ -1353,6 +1355,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2181,6 +2195,68 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3292,6 +3368,44 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3972,6 +4086,46 @@
         "bluebird": "^3.5.5"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -4167,6 +4321,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -4373,7 +4536,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4387,7 +4549,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4792,6 +4953,28 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4799,12 +4982,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/crc": {
       "version": "3.8.0",
@@ -4850,7 +5068,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5079,6 +5296,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5301,7 +5527,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5317,6 +5542,12 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -6123,6 +6354,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -6233,7 +6473,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6243,7 +6482,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6281,7 +6519,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6396,6 +6633,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -6688,6 +6931,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -6740,6 +7013,101 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -6908,6 +7276,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -6995,6 +7384,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -7156,7 +7563,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7181,7 +7587,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7364,7 +7769,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7468,7 +7872,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7503,6 +7906,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -7551,6 +7963,26 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -7748,6 +8180,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8039,6 +8480,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8234,7 +8681,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8341,6 +8787,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -8814,10 +9269,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -9235,7 +9710,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9462,7 +9936,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9472,7 +9945,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9564,6 +10036,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -9726,6 +10210,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9749,7 +10242,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9784,6 +10276,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -9837,6 +10339,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -10047,6 +10558,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -10065,6 +10589,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -10099,6 +10638,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -10537,6 +11116,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10640,7 +11235,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -10691,6 +11285,57 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -10720,6 +11365,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -10771,6 +11435,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -10820,7 +11490,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10833,7 +11502,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10860,7 +11528,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10880,7 +11547,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10897,7 +11563,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10916,7 +11581,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11164,6 +11828,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -11732,6 +12405,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -11815,6 +12497,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -11990,6 +12711,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -12043,6 +12773,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/verror": {
       "version": "1.10.1",
@@ -12659,7 +13398,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12960,6 +13698,24 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "type": "module",
   "main": "dist/main/index.mjs",
   "bin": {
-    "markupr": "./dist/cli/index.mjs"
+    "markupr": "./dist/cli/index.mjs",
+    "markupr-mcp": "./dist/mcp/index.mjs"
   },
   "files": [
-    "dist/cli"
+    "dist/cli",
+    "dist/mcp"
   ],
   "author": "Eddie San Juan",
   "license": "MIT",
@@ -76,6 +78,7 @@
     "generate:installer-images": "node scripts/generate-installer-images.cjs",
     "prebuild:win": "npm run generate:installer-images",
     "build:cli": "node scripts/build-cli.mjs",
+    "build:mcp": "node scripts/build-mcp.mjs",
     "prepublishOnly": "npm run build:cli"
   },
   "devDependencies": {
@@ -96,13 +99,13 @@
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-react-hooks": "^4.0.0",
     "png2icons": "^2.0.1",
-    "sharp": "^0.34.5",
     "typescript": "^5.3.0",
     "vite": "^5.0.0",
     "vitest": "^1.0.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "commander": "^14.0.3",
     "electron-log": "^5.4.3",
     "electron-store": "^11.0.2",
@@ -110,7 +113,9 @@
     "keytar": "^7.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "whisper-node": "^1.1.1"
+    "sharp": "^0.34.5",
+    "whisper-node": "^1.1.1",
+    "zod": "^4.3.6"
   },
   "build": {
     "extends": null

--- a/scripts/build-mcp.mjs
+++ b/scripts/build-mcp.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * build-mcp.mjs - Build the markupr MCP server bundle
+ *
+ * Uses esbuild to bundle src/mcp/index.ts into a single ESM file at
+ * dist/mcp/index.mjs. Node built-ins and select npm packages are kept
+ * external so the bundle stays lean and compatible.
+ */
+
+import { build } from 'esbuild';
+import { readFileSync, chmodSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+
+// Read version from package.json
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8'));
+
+console.log(`[build-mcp] Building markupr MCP server v${pkg.version}...`);
+
+try {
+  await build({
+    entryPoints: [join(repoRoot, 'src/mcp/index.ts')],
+    outfile: join(repoRoot, 'dist/mcp/index.mjs'),
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: 'node18',
+    sourcemap: false,
+    minify: false,
+
+    // Inject version at build time
+    define: {
+      '__MARKUPR_VERSION__': JSON.stringify(pkg.version),
+    },
+
+    // Keep all node_modules external. The MCP server relies on npm-installed
+    // dependencies at runtime (@modelcontextprotocol/sdk, sharp, etc.)
+    packages: 'external',
+
+    // Add shebang banner for direct execution
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
+  });
+
+  // Make the output executable
+  const outputPath = join(repoRoot, 'dist/mcp/index.mjs');
+  chmodSync(outputPath, 0o755);
+
+  console.log(`[build-mcp] Built successfully: dist/mcp/index.mjs`);
+} catch (error) {
+  console.error(`[build-mcp] Build failed:`, error);
+  process.exit(1);
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -33,6 +33,9 @@ if (!isRailwayEnvironment()) {
   console.log('[build] Building CLI...');
   run('node', ['scripts/build-cli.mjs']);
 
+  console.log('[build] Building MCP server...');
+  run('node', ['scripts/build-mcp.mjs']);
+
   console.log('[build] All builds complete.');
   process.exit(0);
 }

--- a/src/mcp/capture/AudioCapture.ts
+++ b/src/mcp/capture/AudioCapture.ts
@@ -1,0 +1,111 @@
+/**
+ * AudioCapture — Headless audio recording using ffmpeg avfoundation.
+ *
+ * Records from the default microphone (or specified device) as 16kHz mono WAV,
+ * which is optimal for Whisper transcription. Zero Electron dependencies.
+ */
+
+import { execFile as execFileCb } from 'child_process';
+import { stat } from 'fs/promises';
+import { resolve } from 'path';
+import { log } from '../utils/Logger.js';
+
+const SAFE_CHILD_ENV = {
+  PATH: process.env.PATH,
+  HOME: process.env.HOME || process.env.USERPROFILE,
+  USERPROFILE: process.env.USERPROFILE,
+  LANG: process.env.LANG,
+  TMPDIR: process.env.TMPDIR || process.env.TEMP,
+  TEMP: process.env.TEMP,
+};
+
+export interface AudioCaptureOptions {
+  /** Recording duration in seconds. */
+  duration: number;
+  /** Absolute path for the output WAV file. */
+  outputPath: string;
+  /** Audio input device name or index (default: "default" = system default mic). */
+  device?: string;
+}
+
+/**
+ * Record audio from the microphone for a fixed duration.
+ *
+ * ffmpeg command:
+ * `ffmpeg -f avfoundation -i ":{device}" -ar 16000 -ac 1 -acodec pcm_f32le -t {duration} {output}`
+ *
+ * @returns Absolute path to the recorded WAV file.
+ * @throws If ffmpeg fails or produces an empty file.
+ */
+export async function record(options: AudioCaptureOptions): Promise<string> {
+  const { duration } = options;
+  const outputPath = resolve(options.outputPath);
+  const device = options.device ?? 'default';
+
+  // avfoundation input: ":device" means audio-only (no video input)
+  const inputDevice = `:${device}`;
+
+  const args = [
+    '-f', 'avfoundation',
+    '-i', inputDevice,
+    '-ar', '16000',
+    '-ac', '1',
+    '-acodec', 'pcm_f32le',
+    '-t', String(duration),
+    '-y', // overwrite output
+    outputPath,
+  ];
+
+  log(`Recording audio: device=${device}, duration=${duration}s, output=${outputPath}`);
+
+  await new Promise<void>((resolve, reject) => {
+    execFileCb(
+      'ffmpeg',
+      args,
+      { env: SAFE_CHILD_ENV, timeout: (duration + 10) * 1000 },
+      (error) => {
+        if (error) {
+          const msg = error.message.toLowerCase();
+          if (msg.includes('permission') || msg.includes('not granted')) {
+            reject(
+              new Error(
+                `Microphone access denied.\n` +
+                  'Grant permission in System Settings → Privacy & Security → Microphone.',
+              ),
+            );
+          } else {
+            reject(
+              new Error(
+                `Audio recording failed: ${error.message}\n` +
+                  'Ensure ffmpeg is installed (brew install ffmpeg) and microphone permission is granted.',
+              ),
+            );
+          }
+          return;
+        }
+        resolve();
+      },
+    );
+  });
+
+  // Validate output
+  let fileStats;
+  try {
+    fileStats = await stat(outputPath);
+  } catch {
+    throw new Error(
+      `Audio file not created at ${outputPath}.\n` +
+        'Check microphone permission in System Settings → Privacy & Security → Microphone.',
+    );
+  }
+
+  if (!fileStats.isFile() || fileStats.size === 0) {
+    throw new Error(
+      'Audio recorded but file is empty (0 bytes). Microphone may not be accessible.\n' +
+        'Check System Settings → Privacy & Security → Microphone.',
+    );
+  }
+
+  log(`Audio recorded: ${outputPath} (${fileStats.size} bytes, ${duration}s)`);
+  return outputPath;
+}

--- a/src/mcp/capture/DeviceDetector.ts
+++ b/src/mcp/capture/DeviceDetector.ts
@@ -1,0 +1,120 @@
+/**
+ * DeviceDetector — Detect avfoundation video and audio devices via ffmpeg.
+ *
+ * Parses the stderr output from `ffmpeg -f avfoundation -list_devices true -i ""`
+ * and returns structured device lists. Zero Electron dependencies.
+ */
+
+import { execFile as execFileCb } from 'child_process';
+import { log } from '../utils/Logger.js';
+
+// Minimal environment for child processes — prevents env variable leakage
+const SAFE_CHILD_ENV = {
+  PATH: process.env.PATH,
+  HOME: process.env.HOME || process.env.USERPROFILE,
+  USERPROFILE: process.env.USERPROFILE,
+  LANG: process.env.LANG,
+  TMPDIR: process.env.TMPDIR || process.env.TEMP,
+  TEMP: process.env.TEMP,
+};
+
+export interface Device {
+  index: number;
+  name: string;
+}
+
+export interface DetectedDevices {
+  video: Device[];
+  audio: Device[];
+}
+
+/**
+ * Detect available avfoundation video and audio devices.
+ *
+ * ffmpeg prints device info to stderr (the command itself "fails" because
+ * the dummy input `""` is invalid, but the device list is still printed).
+ */
+export async function detectDevices(): Promise<DetectedDevices> {
+  const stderr = await runFfmpegDeviceList();
+  return parseDeviceList(stderr);
+}
+
+function runFfmpegDeviceList(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFileCb(
+      'ffmpeg',
+      ['-f', 'avfoundation', '-list_devices', 'true', '-i', ''],
+      { env: SAFE_CHILD_ENV },
+      (_error, _stdout, stderr) => {
+        // ffmpeg always exits non-zero for -list_devices because "" is not a real input.
+        // The device list is in stderr regardless.
+        const output = stderr?.toString() ?? '';
+        if (!output.includes('AVFoundation')) {
+          reject(
+            new Error(
+              'ffmpeg did not return AVFoundation device list. Is ffmpeg installed with avfoundation support?',
+            ),
+          );
+          return;
+        }
+        resolve(output);
+      },
+    );
+  });
+}
+
+/**
+ * Parse ffmpeg avfoundation device list stderr output.
+ *
+ * Expected format:
+ * ```
+ * [AVFoundation indev @ ...] AVFoundation video devices:
+ * [AVFoundation indev @ ...] [0] Capture screen 0
+ * [AVFoundation indev @ ...] [1] FaceTime HD Camera
+ * [AVFoundation indev @ ...] AVFoundation audio devices:
+ * [AVFoundation indev @ ...] [0] MacBook Pro Microphone
+ * [AVFoundation indev @ ...] [1] External Microphone
+ * ```
+ */
+export function parseDeviceList(stderr: string): DetectedDevices {
+  const video: Device[] = [];
+  const audio: Device[] = [];
+
+  let currentCategory: 'video' | 'audio' | null = null;
+
+  // Match lines from AVFoundation device listing
+  const deviceLineRegex = /\[AVFoundation.*?\]\s*\[(\d+)\]\s*(.+)/;
+  const videoHeaderRegex = /AVFoundation video devices/i;
+  const audioHeaderRegex = /AVFoundation audio devices/i;
+
+  for (const line of stderr.split('\n')) {
+    if (videoHeaderRegex.test(line)) {
+      currentCategory = 'video';
+      continue;
+    }
+
+    if (audioHeaderRegex.test(line)) {
+      currentCategory = 'audio';
+      continue;
+    }
+
+    if (currentCategory === null) continue;
+
+    const match = deviceLineRegex.exec(line);
+    if (match) {
+      const device: Device = {
+        index: parseInt(match[1], 10),
+        name: match[2].trim(),
+      };
+
+      if (currentCategory === 'video') {
+        video.push(device);
+      } else {
+        audio.push(device);
+      }
+    }
+  }
+
+  log(`Detected ${video.length} video device(s), ${audio.length} audio device(s)`);
+  return { video, audio };
+}

--- a/src/mcp/capture/ScreenCapture.ts
+++ b/src/mcp/capture/ScreenCapture.ts
@@ -1,0 +1,83 @@
+/**
+ * ScreenCapture — Headless screenshot capture using macOS screencapture CLI.
+ *
+ * Wraps the built-in `screencapture` command. No Electron dependencies.
+ * Requires macOS Screen Recording permission.
+ */
+
+import { execFile as execFileCb } from 'child_process';
+import { stat } from 'fs/promises';
+import { resolve } from 'path';
+import { log } from '../utils/Logger.js';
+
+const SAFE_CHILD_ENV = {
+  PATH: process.env.PATH,
+  HOME: process.env.HOME || process.env.USERPROFILE,
+  USERPROFILE: process.env.USERPROFILE,
+  LANG: process.env.LANG,
+  TMPDIR: process.env.TMPDIR || process.env.TEMP,
+  TEMP: process.env.TEMP,
+};
+
+export interface ScreenCaptureOptions {
+  /** Display number (1-indexed, default 1 = main display). */
+  display?: number;
+  /** Absolute path for the output PNG file. */
+  outputPath: string;
+}
+
+/**
+ * Capture a screenshot of the specified display.
+ *
+ * Uses `screencapture -x -D{display} {outputPath}`:
+ * - `-x` = silent (no shutter sound)
+ * - `-D{n}` = specific display
+ *
+ * @returns Absolute path to the captured PNG image.
+ * @throws If screencapture fails or produces an empty file (permission denied).
+ */
+export async function capture(options: ScreenCaptureOptions): Promise<string> {
+  const display = options.display ?? 1;
+  const outputPath = resolve(options.outputPath);
+
+  const args = ['-x', `-D${display}`, outputPath];
+
+  log(`Capturing screenshot: display=${display}, output=${outputPath}`);
+
+  await new Promise<void>((resolve, reject) => {
+    execFileCb('screencapture', args, { env: SAFE_CHILD_ENV }, (error) => {
+      if (error) {
+        reject(
+          new Error(
+            `screencapture failed: ${error.message}\n` +
+              'Ensure Screen Recording permission is granted in System Settings → Privacy & Security → Screen Recording.',
+          ),
+        );
+        return;
+      }
+      resolve();
+    });
+  });
+
+  // Validate the output file exists and is non-empty
+  // (screencapture may succeed with exit 0 but produce an empty file if permission is denied)
+  let fileStats;
+  try {
+    fileStats = await stat(outputPath);
+  } catch {
+    throw new Error(
+      `Screenshot file not created at ${outputPath}.\n` +
+        'Ensure Screen Recording permission is granted in System Settings → Privacy & Security → Screen Recording.',
+    );
+  }
+
+  if (!fileStats.isFile() || fileStats.size === 0) {
+    throw new Error(
+      'Screenshot captured but file is empty (0 bytes). This typically means Screen Recording permission is not granted.\n' +
+        'Grant permission in System Settings → Privacy & Security → Screen Recording.',
+    );
+  }
+
+  log(`Screenshot captured: ${outputPath} (${fileStats.size} bytes)`);
+  return outputPath;
+}

--- a/src/mcp/capture/ScreenRecorder.ts
+++ b/src/mcp/capture/ScreenRecorder.ts
@@ -1,0 +1,207 @@
+/**
+ * ScreenRecorder — Headless screen + audio recording using ffmpeg avfoundation.
+ *
+ * Provides two modes:
+ * 1. Fixed-duration recording (`record`) — captures for N seconds, returns when done.
+ * 2. Long-form recording (`start`/`stop`) — spawns ffmpeg, caller controls lifetime.
+ *
+ * Settings: 10 fps, ultrafast x264, AAC audio. Produces MP4.
+ * Zero Electron dependencies.
+ */
+
+import { execFile as execFileCb, type ChildProcess } from 'child_process';
+import { stat } from 'fs/promises';
+import { resolve } from 'path';
+import { log } from '../utils/Logger.js';
+
+const SAFE_CHILD_ENV = {
+  PATH: process.env.PATH,
+  HOME: process.env.HOME || process.env.USERPROFILE,
+  USERPROFILE: process.env.USERPROFILE,
+  LANG: process.env.LANG,
+  TMPDIR: process.env.TMPDIR || process.env.TEMP,
+  TEMP: process.env.TEMP,
+};
+
+export interface RecordOptions {
+  /** Recording duration in seconds (for fixed-duration mode). */
+  duration: number;
+  /** Absolute path for the output MP4 file. */
+  outputPath: string;
+  /** Video input device index (default: "1" = first screen). */
+  videoDevice?: string;
+  /** Audio input device name or index (default: "default"). */
+  audioDevice?: string;
+}
+
+export interface StartOptions {
+  /** Absolute path for the output MP4 file. */
+  outputPath: string;
+  /** Video input device index (default: "1" = first screen). */
+  videoDevice?: string;
+  /** Audio input device name or index (default: "default"). */
+  audioDevice?: string;
+}
+
+/**
+ * Build the common ffmpeg args for screen+audio recording.
+ */
+function buildFfmpegArgs(
+  outputPath: string,
+  videoDevice: string,
+  audioDevice: string,
+  duration?: number,
+): string[] {
+  const input = `${videoDevice}:${audioDevice}`;
+
+  const args = [
+    '-f', 'avfoundation',
+    '-framerate', '10',
+    '-i', input,
+    '-vcodec', 'libx264',
+    '-preset', 'ultrafast',
+    '-acodec', 'aac',
+    '-strict', 'experimental',
+  ];
+
+  if (duration !== undefined) {
+    args.push('-t', String(duration));
+  }
+
+  args.push('-y', outputPath);
+
+  return args;
+}
+
+/**
+ * Record screen + audio for a fixed duration.
+ *
+ * @returns Absolute path to the recorded MP4 file.
+ * @throws If ffmpeg fails or produces an empty file.
+ */
+export async function record(options: RecordOptions): Promise<string> {
+  const { duration } = options;
+  const outputPath = resolve(options.outputPath);
+  const videoDevice = options.videoDevice ?? '1';
+  const audioDevice = options.audioDevice ?? 'default';
+
+  const args = buildFfmpegArgs(outputPath, videoDevice, audioDevice, duration);
+
+  log(`Recording screen+audio: duration=${duration}s, output=${outputPath}`);
+
+  await new Promise<void>((resolve, reject) => {
+    execFileCb(
+      'ffmpeg',
+      args,
+      { env: SAFE_CHILD_ENV, timeout: (duration + 30) * 1000 },
+      (error) => {
+        if (error) {
+          reject(
+            new Error(
+              `Screen recording failed: ${error.message}\n` +
+                'Ensure ffmpeg is installed and Screen Recording + Microphone permissions are granted.',
+            ),
+          );
+          return;
+        }
+        resolve();
+      },
+    );
+  });
+
+  await validateOutputFile(outputPath);
+
+  log(`Screen recording complete: ${outputPath}`);
+  return outputPath;
+}
+
+/**
+ * Start a long-form screen + audio recording.
+ *
+ * Returns the spawned ffmpeg ChildProcess. The caller is responsible for
+ * calling `stop(process)` to end the recording cleanly.
+ */
+export function start(options: StartOptions): ChildProcess {
+  const outputPath = resolve(options.outputPath);
+  const videoDevice = options.videoDevice ?? '1';
+  const audioDevice = options.audioDevice ?? 'default';
+
+  const args = buildFfmpegArgs(outputPath, videoDevice, audioDevice);
+
+  log(`Starting long-form recording: output=${outputPath}`);
+
+  // Use execFile but we need the ChildProcess handle, so use spawn-style via execFile callback
+  // Actually, execFile returns the ChildProcess synchronously
+  const child = execFileCb(
+    'ffmpeg',
+    args,
+    { env: SAFE_CHILD_ENV },
+    (error) => {
+      if (error && !error.killed) {
+        // Log but don't throw — the caller handles process lifecycle
+        log(`Recording process exited with error: ${error.message}`);
+      }
+    },
+  );
+
+  return child;
+}
+
+/**
+ * Stop a long-form recording by sending SIGINT to ffmpeg.
+ *
+ * ffmpeg handles SIGINT gracefully — it finalizes the MP4 container
+ * (writes moov atom) before exiting. We wait up to 10 seconds for
+ * clean shutdown before force-killing.
+ */
+export async function stop(process: ChildProcess): Promise<void> {
+  if (process.exitCode !== null) {
+    log('Recording process already exited');
+    return;
+  }
+
+  log('Stopping recording (SIGINT → ffmpeg)...');
+
+  return new Promise<void>((resolve, reject) => {
+    const forceKillTimeout = setTimeout(() => {
+      log('Force-killing recording process (10s timeout exceeded)');
+      process.kill('SIGKILL');
+    }, 10_000);
+
+    process.once('exit', (code) => {
+      clearTimeout(forceKillTimeout);
+      log(`Recording process exited with code ${code}`);
+      resolve();
+    });
+
+    process.once('error', (err) => {
+      clearTimeout(forceKillTimeout);
+      reject(new Error(`Error stopping recording: ${err.message}`));
+    });
+
+    // SIGINT tells ffmpeg to finalize the file cleanly
+    process.kill('SIGINT');
+  });
+}
+
+/**
+ * Validate that an output file exists and is non-empty.
+ */
+async function validateOutputFile(outputPath: string): Promise<void> {
+  let fileStats;
+  try {
+    fileStats = await stat(outputPath);
+  } catch {
+    throw new Error(
+      `Recording file not created at ${outputPath}.\n` +
+        'Check Screen Recording and Microphone permissions in System Settings → Privacy & Security.',
+    );
+  }
+
+  if (!fileStats.isFile() || fileStats.size === 0) {
+    throw new Error(
+      'Recording file is empty (0 bytes). Permissions may not be granted.\n' +
+        'Check System Settings → Privacy & Security → Screen Recording and Microphone.',
+    );
+  }
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,21 @@
+/**
+ * markupr MCP Server — Entry Point
+ *
+ * Headless Node.js process communicating over stdio using JSON-RPC 2.0.
+ * stdout is reserved for MCP protocol — all logging goes to stderr.
+ */
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createServer } from './server.js';
+import { log } from './utils/Logger.js';
+
+// Read version from package.json at build time (injected by esbuild)
+declare const __MARKUPR_VERSION__: string;
+const VERSION =
+  typeof __MARKUPR_VERSION__ !== 'undefined' ? __MARKUPR_VERSION__ : '0.0.0-dev';
+
+log(`markupr MCP server v${VERSION} starting...`);
+
+const server = createServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/src/mcp/resources/sessionResource.ts
+++ b/src/mcp/resources/sessionResource.ts
@@ -1,0 +1,71 @@
+/**
+ * Session Resources — MCP resource registration for session data.
+ *
+ * Registers:
+ *   session://latest   — metadata for the most recent session
+ *   session://{id}     — metadata for a specific session by ID
+ *
+ * Both return application/json content with McpSession fields.
+ */
+
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { sessionStore } from '../session/SessionStore.js';
+
+export function registerResources(server: McpServer): void {
+  // Fixed resource: session://latest
+  server.resource(
+    'latest-session',
+    'session://latest',
+    { description: 'Metadata for the most recent MCP recording session', mimeType: 'application/json' },
+    async () => {
+      const session = await sessionStore.getLatest();
+
+      if (!session) {
+        return {
+          contents: [{
+            uri: 'session://latest',
+            mimeType: 'application/json',
+            text: JSON.stringify({ error: 'No sessions found' }),
+          }],
+        };
+      }
+
+      return {
+        contents: [{
+          uri: 'session://latest',
+          mimeType: 'application/json',
+          text: JSON.stringify(session, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Template resource: session://{id}
+  server.resource(
+    'session-by-id',
+    new ResourceTemplate('session://{id}', { list: undefined }),
+    { description: 'Metadata for a specific MCP recording session', mimeType: 'application/json' },
+    async (uri, variables) => {
+      const id = variables.id as string;
+      const session = await sessionStore.get(id);
+
+      if (!session) {
+        return {
+          contents: [{
+            uri: uri.href,
+            mimeType: 'application/json',
+            text: JSON.stringify({ error: `Session not found: ${id}` }),
+          }],
+        };
+      }
+
+      return {
+        contents: [{
+          uri: uri.href,
+          mimeType: 'application/json',
+          text: JSON.stringify(session, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,44 @@
+/**
+ * MCP Server Factory
+ *
+ * Creates and configures the markupr MCP server with all tool and resource
+ * registrations wired in.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Tool registrations
+import { register as registerCaptureScreenshot } from './tools/captureScreenshot.js';
+import { register as registerCaptureWithVoice } from './tools/captureWithVoice.js';
+import { register as registerAnalyzeVideo } from './tools/analyzeVideo.js';
+import { register as registerAnalyzeScreenshot } from './tools/analyzeScreenshot.js';
+import { register as registerStartRecording } from './tools/startRecording.js';
+import { register as registerStopRecording } from './tools/stopRecording.js';
+
+// Resource registrations
+import { registerResources } from './resources/sessionResource.js';
+
+// Read version from package.json at build time (injected by esbuild)
+declare const __MARKUPR_VERSION__: string;
+const VERSION =
+  typeof __MARKUPR_VERSION__ !== 'undefined' ? __MARKUPR_VERSION__ : '0.0.0-dev';
+
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: 'markupr',
+    version: VERSION,
+  });
+
+  // Register all 6 tools
+  registerCaptureScreenshot(server);
+  registerCaptureWithVoice(server);
+  registerAnalyzeVideo(server);
+  registerAnalyzeScreenshot(server);
+  registerStartRecording(server);
+  registerStopRecording(server);
+
+  // Register resources (session://latest, session://{id})
+  registerResources(server);
+
+  return server;
+}

--- a/src/mcp/session/ActiveRecording.ts
+++ b/src/mcp/session/ActiveRecording.ts
@@ -1,0 +1,67 @@
+/**
+ * Active Recording — Singleton lock for the currently running recording.
+ *
+ * Enforces a single-recording constraint: only one ffmpeg recording process
+ * can be active at a time. Tools call start()/stop() to manage the lifecycle.
+ *
+ * NO Electron dependencies.
+ */
+
+import type { ChildProcess } from 'child_process';
+import { log } from '../utils/Logger.js';
+
+interface RecordingState {
+  sessionId: string;
+  process: ChildProcess;
+  videoPath: string;
+}
+
+export class ActiveRecording {
+  private current: RecordingState | null = null;
+
+  /**
+   * Start tracking a recording. Throws if one is already in progress.
+   */
+  start(sessionId: string, process: ChildProcess, videoPath: string): void {
+    if (this.current !== null) {
+      throw new Error(
+        `Recording already in progress (session: ${this.current.sessionId}). ` +
+        `Stop it before starting a new one.`
+      );
+    }
+
+    this.current = { sessionId, process, videoPath };
+    log(`Active recording started: ${sessionId}`);
+  }
+
+  /**
+   * Stop tracking the current recording. Returns the session ID and video path.
+   * Throws if no recording is active.
+   */
+  stop(): { sessionId: string; videoPath: string } {
+    if (this.current === null) {
+      throw new Error('No recording in progress.');
+    }
+
+    const { sessionId, videoPath } = this.current;
+    this.current = null;
+    log(`Active recording stopped: ${sessionId}`);
+    return { sessionId, videoPath };
+  }
+
+  /**
+   * Check if a recording is currently active.
+   */
+  isRecording(): boolean {
+    return this.current !== null;
+  }
+
+  /**
+   * Get the current recording state (read-only), or null.
+   */
+  getCurrent(): Readonly<RecordingState> | null {
+    return this.current;
+  }
+}
+
+export const activeRecording = new ActiveRecording();

--- a/src/mcp/session/SessionStore.ts
+++ b/src/mcp/session/SessionStore.ts
@@ -1,0 +1,186 @@
+/**
+ * Session Store — Disk-persisted session lifecycle management.
+ *
+ * Storage layout:
+ *   ~/Documents/markupr/mcp/
+ *     mcp-YYYYMMDD-HHMMSS/
+ *       metadata.json   — McpSessionMetadata
+ *       screenshots/     — captured frames
+ *       ...
+ *
+ * Uses os.homedir() — NO Electron dependencies.
+ * Directory naming mirrors FileManager pattern (src/main/output/FileManager.ts).
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { log } from '../utils/Logger.js';
+import type { McpSession, McpSessionMetadata } from '../types.js';
+
+const BASE_DIR = path.join(os.homedir(), 'Documents', 'markupr', 'mcp');
+
+export class SessionStore {
+  private baseDir: string;
+
+  constructor(baseDir?: string) {
+    this.baseDir = baseDir ?? BASE_DIR;
+  }
+
+  /**
+   * Create a new session directory with metadata.json.
+   */
+  async create(label?: string): Promise<McpSession> {
+    await fs.mkdir(this.baseDir, { recursive: true });
+
+    const now = Date.now();
+    const id = this.formatSessionId(now);
+    const sessionDir = path.join(this.baseDir, id);
+
+    // Handle conflicts by appending counter
+    let finalDir = sessionDir;
+    let counter = 1;
+    while (await this.exists(finalDir)) {
+      finalDir = path.join(this.baseDir, `${id}-${counter}`);
+      counter++;
+    }
+
+    const finalId = path.basename(finalDir);
+    await fs.mkdir(finalDir, { recursive: true });
+    await fs.mkdir(path.join(finalDir, 'screenshots'), { recursive: true });
+
+    const session: McpSession = {
+      id: finalId,
+      startTime: now,
+      label,
+      status: 'recording',
+    };
+
+    const metadata: McpSessionMetadata = { ...session };
+    await this.writeMetadata(finalDir, metadata);
+
+    log(`Session created: ${finalId}`);
+    return session;
+  }
+
+  /**
+   * Read a session's metadata by ID.
+   */
+  async get(id: string): Promise<McpSession | null> {
+    const metadataPath = path.join(this.baseDir, id, 'metadata.json');
+    try {
+      const raw = await fs.readFile(metadataPath, 'utf-8');
+      return JSON.parse(raw) as McpSession;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Return the most recent session (by startTime).
+   */
+  async getLatest(): Promise<McpSession | null> {
+    const sessions = await this.list();
+    return sessions[0] ?? null;
+  }
+
+  /**
+   * List all sessions sorted by startTime descending.
+   */
+  async list(): Promise<McpSession[]> {
+    const sessions: McpSession[] = [];
+
+    try {
+      await fs.access(this.baseDir);
+    } catch {
+      return sessions;
+    }
+
+    let entries;
+    try {
+      entries = await fs.readdir(this.baseDir, { withFileTypes: true });
+    } catch {
+      return sessions;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const metadataPath = path.join(this.baseDir, entry.name, 'metadata.json');
+      try {
+        const raw = await fs.readFile(metadataPath, 'utf-8');
+        const session = JSON.parse(raw) as McpSession;
+        sessions.push(session);
+      } catch {
+        // Skip directories without valid metadata
+      }
+    }
+
+    sessions.sort((a, b) => b.startTime - a.startTime);
+    return sessions;
+  }
+
+  /**
+   * Update a session's metadata (partial merge).
+   */
+  async update(id: string, data: Partial<McpSession>): Promise<void> {
+    const sessionDir = path.join(this.baseDir, id);
+    const metadataPath = path.join(sessionDir, 'metadata.json');
+
+    let existing: McpSessionMetadata;
+    try {
+      const raw = await fs.readFile(metadataPath, 'utf-8');
+      existing = JSON.parse(raw) as McpSessionMetadata;
+    } catch {
+      throw new Error(`Session not found: ${id}`);
+    }
+
+    const updated: McpSessionMetadata = { ...existing, ...data };
+    await this.writeMetadata(sessionDir, updated);
+    log(`Session updated: ${id}`);
+  }
+
+  /**
+   * Get the absolute path to a session directory.
+   */
+  getSessionDir(id: string): string {
+    return path.join(this.baseDir, id);
+  }
+
+  /**
+   * Format a timestamp into the session ID pattern: mcp-YYYYMMDD-HHMMSS
+   */
+  private formatSessionId(timestamp: number): string {
+    const date = new Date(timestamp);
+
+    const dateStr = [
+      date.getFullYear(),
+      String(date.getMonth() + 1).padStart(2, '0'),
+      String(date.getDate()).padStart(2, '0'),
+    ].join('');
+
+    const timeStr = [
+      String(date.getHours()).padStart(2, '0'),
+      String(date.getMinutes()).padStart(2, '0'),
+      String(date.getSeconds()).padStart(2, '0'),
+    ].join('');
+
+    return `mcp-${dateStr}-${timeStr}`;
+  }
+
+  private async writeMetadata(sessionDir: string, metadata: McpSessionMetadata): Promise<void> {
+    const metadataPath = path.join(sessionDir, 'metadata.json');
+    await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8');
+  }
+
+  private async exists(dir: string): Promise<boolean> {
+    try {
+      await fs.access(dir);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export const sessionStore = new SessionStore();

--- a/src/mcp/tools/analyzeScreenshot.ts
+++ b/src/mcp/tools/analyzeScreenshot.ts
@@ -1,0 +1,72 @@
+/**
+ * Tool: analyze_screenshot
+ *
+ * Takes a screenshot and returns it as ImageContent for the AI to analyze
+ * visually. Unlike capture_screenshot, this returns the image data directly
+ * as base64 for vision analysis rather than just saving to disk.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { join } from 'path';
+import { readFile, unlink } from 'fs/promises';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+import { capture } from '../capture/ScreenCapture.js';
+import { optimize } from '../utils/ImageOptimizer.js';
+import { log } from '../utils/Logger.js';
+
+export function register(server: McpServer): void {
+  server.tool(
+    'analyze_screenshot',
+    'Take a screenshot and return it as an image for the AI to analyze visually. Returns the image data directly for vision analysis.',
+    {
+      display: z.number().optional().default(1).describe('Display number (1-indexed)'),
+      question: z.string().optional().describe('What to look for in the screenshot'),
+    },
+    async ({ display, question }) => {
+      const tempPath = join(tmpdir(), `markupr-mcp-screenshot-${randomUUID()}.png`);
+
+      try {
+        log(`Capturing screenshot for analysis: display=${display}`);
+
+        // Capture screenshot to temp file
+        await capture({ display, outputPath: tempPath });
+
+        // Optimize for API efficiency
+        await optimize(tempPath);
+
+        // Read as base64
+        const imageBuffer = await readFile(tempPath);
+        const base64Data = imageBuffer.toString('base64');
+
+        const timestamp = new Date().toISOString();
+        const description = question
+          ? `Screenshot of display ${display} captured at ${timestamp}. Question: ${question}`
+          : `Screenshot of display ${display} captured at ${timestamp}`;
+
+        return {
+          content: [
+            {
+              type: 'image' as const,
+              data: base64Data,
+              mimeType: 'image/png',
+            },
+            {
+              type: 'text' as const,
+              text: description,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      } finally {
+        // Clean up temp file
+        await unlink(tempPath).catch(() => {});
+      }
+    },
+  );
+}

--- a/src/mcp/tools/analyzeVideo.ts
+++ b/src/mcp/tools/analyzeVideo.ts
@@ -1,0 +1,117 @@
+/**
+ * Tool: analyze_video
+ *
+ * Process an existing video file through the markupr pipeline.
+ * Generates a structured markdown report with transcript, key moments,
+ * and extracted frames.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { stat } from 'fs/promises';
+import { sessionStore } from '../session/SessionStore.js';
+import { log } from '../utils/Logger.js';
+import { CLIPipeline } from '../../cli/CLIPipeline.js';
+
+export function register(server: McpServer): void {
+  server.tool(
+    'analyze_video',
+    'Process an existing video file through the markupr pipeline. Generates a structured markdown report with transcript, key moments, and extracted frames.',
+    {
+      videoPath: z.string().describe('Absolute path to the video file'),
+      audioPath: z.string().optional().describe('Separate audio file path (if not embedded)'),
+      outputDir: z.string().optional().describe('Output directory (default: session directory)'),
+      skipFrames: z.boolean().optional().default(false).describe('Skip frame extraction'),
+    },
+    async ({ videoPath, audioPath, outputDir, skipFrames }) => {
+      try {
+        // Validate video file exists and is non-empty
+        let fileStats;
+        try {
+          fileStats = await stat(videoPath);
+        } catch {
+          return {
+            content: [{ type: 'text', text: `Error: Video file not found: ${videoPath}` }],
+            isError: true,
+          };
+        }
+
+        if (!fileStats.isFile() || fileStats.size === 0) {
+          return {
+            content: [{ type: 'text', text: `Error: Video file is empty or not a regular file: ${videoPath}` }],
+            isError: true,
+          };
+        }
+
+        // Validate audio file if provided
+        if (audioPath) {
+          try {
+            const audioStats = await stat(audioPath);
+            if (!audioStats.isFile() || audioStats.size === 0) {
+              return {
+                content: [{ type: 'text', text: `Error: Audio file is empty or not a regular file: ${audioPath}` }],
+                isError: true,
+              };
+            }
+          } catch {
+            return {
+              content: [{ type: 'text', text: `Error: Audio file not found: ${audioPath}` }],
+              isError: true,
+            };
+          }
+        }
+
+        // Create session for tracking
+        const session = await sessionStore.create();
+        const sessionDir = sessionStore.getSessionDir(session.id);
+        const pipelineOutputDir = outputDir ?? sessionDir;
+
+        log(`Analyzing video: ${videoPath}`);
+
+        const pipeline = new CLIPipeline(
+          {
+            videoPath,
+            audioPath,
+            outputDir: pipelineOutputDir,
+            skipFrames,
+            verbose: false,
+          },
+          (msg) => log(msg),
+        );
+
+        const result = await pipeline.run();
+
+        // Update session
+        await sessionStore.update(session.id, {
+          status: 'complete',
+          endTime: Date.now(),
+          videoPath,
+          reportPath: result.outputPath,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: [
+                `Video analysis complete`,
+                'Pipeline results:',
+                `  Transcript segments: ${result.transcriptSegments}`,
+                `  Extracted frames: ${result.extractedFrames}`,
+                `  Processing time: ${result.durationSeconds.toFixed(1)}s`,
+                '',
+                `Report: ${result.outputPath}`,
+                `OUTPUT:${result.outputPath}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/mcp/tools/captureScreenshot.ts
+++ b/src/mcp/tools/captureScreenshot.ts
@@ -1,0 +1,67 @@
+/**
+ * Tool: capture_screenshot
+ *
+ * Takes a screenshot of the current screen, optionally optimizes it,
+ * and saves it to the session directory. Returns a markdown image reference.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { join } from 'path';
+import { readdir } from 'fs/promises';
+import { capture } from '../capture/ScreenCapture.js';
+import { optimize } from '../utils/ImageOptimizer.js';
+import { sessionStore } from '../session/SessionStore.js';
+import { log } from '../utils/Logger.js';
+
+export function register(server: McpServer): void {
+  server.tool(
+    'capture_screenshot',
+    'Take a screenshot of the current screen, optimize it, and save to the session directory. Returns a markdown image reference.',
+    {
+      label: z.string().optional().describe('Optional label for the screenshot'),
+      display: z.number().optional().default(1).describe('Display number (1-indexed)'),
+      optimize: z.boolean().optional().default(true).describe('Optimize image size with sharp'),
+    },
+    async ({ label, display, optimize: shouldOptimize }) => {
+      try {
+        // Create or reuse latest session
+        const session = await sessionStore.create(label);
+        const sessionDir = sessionStore.getSessionDir(session.id);
+        const screenshotsDir = join(sessionDir, 'screenshots');
+
+        // Determine sequential filename
+        const existing = await readdir(screenshotsDir).catch(() => []);
+        const index = existing.filter((f) => f.startsWith('screenshot-')).length + 1;
+        const filename = `screenshot-${String(index).padStart(3, '0')}.png`;
+        const outputPath = join(screenshotsDir, filename);
+
+        log(`Capturing screenshot: display=${display}, label=${label ?? 'none'}`);
+
+        // Capture
+        await capture({ display, outputPath });
+
+        // Optimize if requested
+        if (shouldOptimize) {
+          await optimize(outputPath);
+        }
+
+        const markdownRef = `![${label ?? filename}](screenshots/${filename})`;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Screenshot saved: ${outputPath}\n${markdownRef}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/mcp/tools/captureWithVoice.ts
+++ b/src/mcp/tools/captureWithVoice.ts
@@ -1,0 +1,84 @@
+/**
+ * Tool: capture_with_voice
+ *
+ * Records screen and voice for a specified duration, then runs the full
+ * markupr pipeline to produce a structured feedback report.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { join } from 'path';
+import { record } from '../capture/ScreenRecorder.js';
+import { sessionStore } from '../session/SessionStore.js';
+import { log } from '../utils/Logger.js';
+import { CLIPipeline } from '../../cli/CLIPipeline.js';
+
+export function register(server: McpServer): void {
+  server.tool(
+    'capture_with_voice',
+    'Record screen and voice for a specified duration, then run the full markupr pipeline to produce a structured feedback report.',
+    {
+      duration: z.number().min(3).max(300).describe('Recording duration in seconds (3-300)'),
+      outputDir: z.string().optional().describe('Output directory (default: session directory)'),
+      skipFrames: z.boolean().optional().default(false).describe('Skip frame extraction'),
+    },
+    async ({ duration, outputDir, skipFrames }) => {
+      try {
+        // Create session
+        const session = await sessionStore.create();
+        const sessionDir = sessionStore.getSessionDir(session.id);
+        const videoPath = join(sessionDir, 'recording.mp4');
+
+        log(`Starting capture_with_voice: duration=${duration}s`);
+
+        // Record screen + audio
+        await record({ duration, outputPath: videoPath });
+
+        // Run pipeline
+        const pipelineOutputDir = outputDir ?? sessionDir;
+        const pipeline = new CLIPipeline(
+          {
+            videoPath,
+            outputDir: pipelineOutputDir,
+            skipFrames,
+            verbose: false,
+          },
+          (msg) => log(msg),
+        );
+
+        const result = await pipeline.run();
+
+        // Update session metadata
+        await sessionStore.update(session.id, {
+          status: 'complete',
+          endTime: Date.now(),
+          videoPath,
+          reportPath: result.outputPath,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: [
+                `Recording complete: ${duration} seconds captured`,
+                'Pipeline results:',
+                `  Transcript segments: ${result.transcriptSegments}`,
+                `  Extracted frames: ${result.extractedFrames}`,
+                `  Processing time: ${result.durationSeconds.toFixed(1)}s`,
+                '',
+                `Report: ${result.outputPath}`,
+                `OUTPUT:${result.outputPath}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/mcp/tools/startRecording.ts
+++ b/src/mcp/tools/startRecording.ts
@@ -1,0 +1,73 @@
+/**
+ * Tool: start_recording
+ *
+ * Start a long-form screen+voice recording session. Returns a session ID
+ * that can be used with stop_recording.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { join } from 'path';
+import { start } from '../capture/ScreenRecorder.js';
+import { activeRecording } from '../session/ActiveRecording.js';
+import { sessionStore } from '../session/SessionStore.js';
+import { log } from '../utils/Logger.js';
+
+export function register(server: McpServer): void {
+  server.tool(
+    'start_recording',
+    'Start a long-form screen+voice recording session. Returns a session ID that can be used with stop_recording.',
+    {
+      label: z.string().optional().describe('Session label for organization'),
+    },
+    async ({ label }) => {
+      try {
+        // Check if already recording
+        if (activeRecording.isRecording()) {
+          const current = activeRecording.getCurrent();
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error: Recording already in progress (session: ${current?.sessionId}). Stop it before starting a new one.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        // Create session
+        const session = await sessionStore.create(label);
+        const sessionDir = sessionStore.getSessionDir(session.id);
+        const videoPath = join(sessionDir, 'recording.mp4');
+
+        log(`Starting long-form recording: session=${session.id}`);
+
+        // Start recording (returns immediately with ffmpeg process handle)
+        const process = start({ outputPath: videoPath });
+
+        // Track in active recording lock
+        activeRecording.start(session.id, process, videoPath);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: [
+                'Recording started.',
+                `Session ID: ${session.id}`,
+                'Status: recording',
+                'Use stop_recording to end and process the recording.',
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/mcp/tools/stopRecording.ts
+++ b/src/mcp/tools/stopRecording.ts
@@ -1,0 +1,101 @@
+/**
+ * Tool: stop_recording
+ *
+ * Stop an active recording and run the full markupr pipeline on the
+ * captured video. Returns the report path and summary stats.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { stop } from '../capture/ScreenRecorder.js';
+import { activeRecording } from '../session/ActiveRecording.js';
+import { sessionStore } from '../session/SessionStore.js';
+import { log } from '../utils/Logger.js';
+import { CLIPipeline } from '../../cli/CLIPipeline.js';
+
+export function register(server: McpServer): void {
+  server.tool(
+    'stop_recording',
+    'Stop an active recording and run the full markupr pipeline on the captured video.',
+    {
+      sessionId: z.string().optional().describe('Session ID (default: current active recording)'),
+      skipFrames: z.boolean().optional().default(false).describe('Skip frame extraction'),
+    },
+    async ({ sessionId: _requestedSessionId, skipFrames }) => {
+      try {
+        // Verify there's an active recording
+        if (!activeRecording.isRecording()) {
+          return {
+            content: [{ type: 'text', text: 'Error: No recording in progress.' }],
+            isError: true,
+          };
+        }
+
+        const current = activeRecording.getCurrent();
+        if (!current) {
+          return {
+            content: [{ type: 'text', text: 'Error: No recording in progress.' }],
+            isError: true,
+          };
+        }
+
+        log(`Stopping recording: session=${current.sessionId}`);
+
+        // Stop the ffmpeg process gracefully
+        await stop(current.process);
+
+        // Release the lock and get recording info
+        const { sessionId, videoPath } = activeRecording.stop();
+
+        // Update session status to processing
+        await sessionStore.update(sessionId, { status: 'processing' });
+
+        // Run pipeline
+        const sessionDir = sessionStore.getSessionDir(sessionId);
+        const pipeline = new CLIPipeline(
+          {
+            videoPath,
+            outputDir: sessionDir,
+            skipFrames,
+            verbose: false,
+          },
+          (msg) => log(msg),
+        );
+
+        const result = await pipeline.run();
+
+        // Update session with results
+        await sessionStore.update(sessionId, {
+          status: 'complete',
+          endTime: Date.now(),
+          videoPath,
+          reportPath: result.outputPath,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: [
+                `Recording stopped and processed.`,
+                `Session: ${sessionId}`,
+                'Pipeline results:',
+                `  Transcript segments: ${result.transcriptSegments}`,
+                `  Extracted frames: ${result.extractedFrames}`,
+                `  Processing time: ${result.durationSeconds.toFixed(1)}s`,
+                '',
+                `Report: ${result.outputPath}`,
+                `OUTPUT:${result.outputPath}`,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,21 @@
+/**
+ * MCP-specific types for the markupr MCP server.
+ */
+
+/** Represents a single MCP recording/capture session. */
+export interface McpSession {
+  id: string;
+  startTime: number;
+  endTime?: number;
+  label?: string;
+  videoPath?: string;
+  reportPath?: string;
+  status: 'recording' | 'processing' | 'complete' | 'error';
+}
+
+/** Metadata written to each session's metadata.json on disk. */
+export interface McpSessionMetadata extends McpSession {
+  transcriptSegments?: number;
+  extractedFrames?: number;
+  durationSeconds?: number;
+}

--- a/src/mcp/utils/ImageOptimizer.ts
+++ b/src/mcp/utils/ImageOptimizer.ts
@@ -1,0 +1,73 @@
+/**
+ * ImageOptimizer — sharp-based image optimization for the MCP server.
+ *
+ * Replaces the Electron nativeImage approach from src/main/ai/ImageOptimizer.ts.
+ * Resizes images to a max width and compresses to reduce size for API transport
+ * and disk storage. Zero Electron dependencies.
+ */
+
+import sharp from 'sharp';
+import { resolve } from 'path';
+import { log } from './Logger.js';
+
+export interface OptimizeOptions {
+  /** Maximum width in pixels. Images wider than this are resized (aspect ratio preserved). Default: 1920. */
+  maxWidth?: number;
+  /** JPEG/PNG quality (1-100). Default: 85. */
+  quality?: number;
+}
+
+const DEFAULT_MAX_WIDTH = 1920;
+const DEFAULT_QUALITY = 85;
+
+/**
+ * Optimize an image by resizing and compressing it.
+ *
+ * - Images wider than maxWidth are scaled down (aspect ratio preserved).
+ * - PNG images are re-encoded at the specified quality.
+ * - If outputPath is not provided, the input file is overwritten.
+ *
+ * @param inputPath  Absolute path to the source image.
+ * @param outputPath Optional output path. Defaults to overwriting inputPath.
+ * @param options    Resize and compression options.
+ * @returns Absolute path to the optimized image.
+ */
+export async function optimize(
+  inputPath: string,
+  outputPath?: string,
+  options?: OptimizeOptions,
+): Promise<string> {
+  const resolvedInput = resolve(inputPath);
+  const resolvedOutput = resolve(outputPath ?? inputPath);
+  const maxWidth = options?.maxWidth ?? DEFAULT_MAX_WIDTH;
+  const quality = options?.quality ?? DEFAULT_QUALITY;
+
+  const metadata = await sharp(resolvedInput).metadata();
+  const originalWidth = metadata.width ?? 0;
+  const originalHeight = metadata.height ?? 0;
+
+  let pipeline = sharp(resolvedInput);
+
+  // Resize if wider than maxWidth
+  if (originalWidth > maxWidth) {
+    pipeline = pipeline.resize({ width: maxWidth, withoutEnlargement: true });
+    log(
+      `Resizing image: ${originalWidth}x${originalHeight} → max width ${maxWidth}px`,
+    );
+  }
+
+  // Determine output format from extension
+  const ext = resolvedOutput.split('.').pop()?.toLowerCase();
+
+  if (ext === 'jpg' || ext === 'jpeg') {
+    pipeline = pipeline.jpeg({ quality });
+  } else {
+    // Default to PNG
+    pipeline = pipeline.png({ quality: Math.min(quality, 100) });
+  }
+
+  await pipeline.toFile(resolvedOutput);
+
+  log(`Image optimized: ${resolvedOutput}`);
+  return resolvedOutput;
+}

--- a/src/mcp/utils/Logger.ts
+++ b/src/mcp/utils/Logger.ts
@@ -1,0 +1,10 @@
+/**
+ * stderr-only logger for the MCP server.
+ *
+ * stdout is reserved for MCP JSON-RPC protocol traffic.
+ * All diagnostic/debug output MUST go to stderr.
+ */
+
+export function log(message: string): void {
+  process.stderr.write(`[markupr-mcp] ${message}\n`);
+}

--- a/src/mcp/utils/Permissions.ts
+++ b/src/mcp/utils/Permissions.ts
@@ -1,0 +1,187 @@
+/**
+ * Permissions — Detect macOS permissions for screen recording, microphone, and ffmpeg.
+ *
+ * Uses a practical approach: attempt each operation and check the result.
+ * Returns actionable error messages telling the user which System Settings
+ * pane to visit. Zero Electron dependencies.
+ */
+
+import { execFile as execFileCb } from 'child_process';
+import { stat, unlink } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+import { log } from './Logger.js';
+
+const SAFE_CHILD_ENV = {
+  PATH: process.env.PATH,
+  HOME: process.env.HOME || process.env.USERPROFILE,
+  USERPROFILE: process.env.USERPROFILE,
+  LANG: process.env.LANG,
+  TMPDIR: process.env.TMPDIR || process.env.TEMP,
+  TEMP: process.env.TEMP,
+};
+
+export interface PermissionStatus {
+  granted: boolean;
+  error?: string;
+}
+
+/**
+ * Check if Screen Recording permission is granted.
+ *
+ * Attempts a silent screencapture and checks if the output is a valid,
+ * non-empty PNG. An empty or missing file indicates permission is denied.
+ */
+export async function checkScreenRecording(): Promise<PermissionStatus> {
+  const testPath = join(tmpdir(), `markupr-perm-test-${randomUUID()}.png`);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      execFileCb(
+        'screencapture',
+        ['-x', testPath],
+        { env: SAFE_CHILD_ENV, timeout: 10_000 },
+        (error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        },
+      );
+    });
+
+    const fileStats = await stat(testPath);
+    if (fileStats.size === 0) {
+      return {
+        granted: false,
+        error:
+          'Screen Recording permission is not granted.\n' +
+          'Grant permission in System Settings → Privacy & Security → Screen Recording.',
+      };
+    }
+
+    log('Screen Recording permission: granted');
+    return { granted: true };
+  } catch {
+    return {
+      granted: false,
+      error:
+        'Screen Recording permission check failed.\n' +
+        'Grant permission in System Settings → Privacy & Security → Screen Recording.',
+    };
+  } finally {
+    // Clean up test file
+    await unlink(testPath).catch(() => {});
+  }
+}
+
+/**
+ * Check if Microphone permission is granted.
+ *
+ * Attempts a 0.1s audio recording with ffmpeg and checks for a valid output.
+ */
+export async function checkMicrophone(): Promise<PermissionStatus> {
+  const testPath = join(tmpdir(), `markupr-mic-test-${randomUUID()}.wav`);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      execFileCb(
+        'ffmpeg',
+        [
+          '-f', 'avfoundation',
+          '-i', ':default',
+          '-ar', '16000',
+          '-ac', '1',
+          '-t', '0.1',
+          '-y',
+          testPath,
+        ],
+        { env: SAFE_CHILD_ENV, timeout: 10_000 },
+        (error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        },
+      );
+    });
+
+    const fileStats = await stat(testPath);
+    if (fileStats.size === 0) {
+      return {
+        granted: false,
+        error:
+          'Microphone permission is not granted.\n' +
+          'Grant permission in System Settings → Privacy & Security → Microphone.',
+      };
+    }
+
+    log('Microphone permission: granted');
+    return { granted: true };
+  } catch {
+    return {
+      granted: false,
+      error:
+        'Microphone permission check failed.\n' +
+        'Grant permission in System Settings → Privacy & Security → Microphone.\n' +
+        'Also ensure ffmpeg is installed: brew install ffmpeg',
+    };
+  } finally {
+    await unlink(testPath).catch(() => {});
+  }
+}
+
+/**
+ * Check if ffmpeg is installed and accessible on PATH.
+ */
+export async function checkFfmpeg(): Promise<PermissionStatus> {
+  try {
+    const version = await new Promise<string>((resolve, reject) => {
+      execFileCb(
+        'ffmpeg',
+        ['-version'],
+        { env: SAFE_CHILD_ENV, timeout: 5_000 },
+        (error, stdout) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(stdout?.toString() ?? '');
+        },
+      );
+    });
+
+    // Extract first line (e.g. "ffmpeg version 6.1 ...")
+    const firstLine = version.split('\n')[0]?.trim() ?? 'unknown version';
+    log(`ffmpeg available: ${firstLine}`);
+    return { granted: true };
+  } catch {
+    return {
+      granted: false,
+      error:
+        'ffmpeg is not installed or not on PATH.\n' +
+        'Install via: brew install ffmpeg\n' +
+        'Screenshot-only tools will still work without ffmpeg.',
+    };
+  }
+}
+
+/**
+ * Run all permission checks and return a summary.
+ */
+export async function checkAll(): Promise<{
+  screenRecording: PermissionStatus;
+  microphone: PermissionStatus;
+  ffmpeg: PermissionStatus;
+}> {
+  const [screenRecording, microphone, ffmpeg] = await Promise.all([
+    checkScreenRecording(),
+    checkMicrophone(),
+    checkFfmpeg(),
+  ]);
+
+  return { screenRecording, microphone, ffmpeg };
+}

--- a/tests/manual/test-mcp-server.sh
+++ b/tests/manual/test-mcp-server.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Manual MCP Server Test — sends JSON-RPC messages over stdio
+#
+# Usage:
+#   ./tests/manual/test-mcp-server.sh
+#
+# Prerequisites:
+#   npm run build:mcp
+
+set -euo pipefail
+
+MCP_BIN="node dist/mcp/index.mjs"
+
+echo "=== MCP Server Manual Test ==="
+echo ""
+
+# Test 1: Initialize
+echo "--- Test 1: Initialize ---"
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}' | $MCP_BIN 2>/dev/null || true
+echo ""
+
+# Test 2: List tools
+echo "--- Test 2: List Tools ---"
+echo -e '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | $MCP_BIN 2>/dev/null || true
+echo ""
+
+echo "=== Done ==="

--- a/tests/unit/mcp/activeRecording.test.ts
+++ b/tests/unit/mcp/activeRecording.test.ts
@@ -1,0 +1,121 @@
+/**
+ * ActiveRecording Unit Tests
+ *
+ * Tests the singleton recording lock:
+ * - start() tracks a recording
+ * - start() throws if already recording
+ * - stop() clears the recording and returns session info
+ * - stop() throws if no recording active
+ * - isRecording() returns correct boolean
+ * - getCurrent() returns state or null
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChildProcess } from 'child_process';
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+import { ActiveRecording } from '../../../src/mcp/session/ActiveRecording.js';
+
+describe('ActiveRecording', () => {
+  let recording: ActiveRecording;
+  let mockProcess: ChildProcess;
+
+  beforeEach(() => {
+    recording = new ActiveRecording();
+    mockProcess = { pid: 1234 } as unknown as ChildProcess;
+  });
+
+  describe('start', () => {
+    it('tracks a new recording', () => {
+      recording.start('session-1', mockProcess, '/tmp/video.mp4');
+      expect(recording.isRecording()).toBe(true);
+    });
+
+    it('throws if a recording is already in progress', () => {
+      recording.start('session-1', mockProcess, '/tmp/video.mp4');
+
+      expect(() => {
+        recording.start('session-2', mockProcess, '/tmp/video2.mp4');
+      }).toThrow('Recording already in progress');
+    });
+
+    it('includes the active session ID in the error message', () => {
+      recording.start('session-1', mockProcess, '/tmp/video.mp4');
+
+      expect(() => {
+        recording.start('session-2', mockProcess, '/tmp/video2.mp4');
+      }).toThrow('session-1');
+    });
+  });
+
+  describe('stop', () => {
+    it('clears the recording and returns session info', () => {
+      recording.start('session-1', mockProcess, '/tmp/video.mp4');
+
+      const result = recording.stop();
+
+      expect(result.sessionId).toBe('session-1');
+      expect(result.videoPath).toBe('/tmp/video.mp4');
+      expect(recording.isRecording()).toBe(false);
+    });
+
+    it('throws if no recording is active', () => {
+      expect(() => recording.stop()).toThrow('No recording in progress');
+    });
+  });
+
+  describe('isRecording', () => {
+    it('returns false initially', () => {
+      expect(recording.isRecording()).toBe(false);
+    });
+
+    it('returns true when recording is active', () => {
+      recording.start('session-1', mockProcess, '/tmp/video.mp4');
+      expect(recording.isRecording()).toBe(true);
+    });
+
+    it('returns false after stop', () => {
+      recording.start('session-1', mockProcess, '/tmp/video.mp4');
+      recording.stop();
+      expect(recording.isRecording()).toBe(false);
+    });
+  });
+
+  describe('getCurrent', () => {
+    it('returns null when no recording active', () => {
+      expect(recording.getCurrent()).toBeNull();
+    });
+
+    it('returns current state when recording', () => {
+      recording.start('session-1', mockProcess, '/tmp/video.mp4');
+
+      const current = recording.getCurrent();
+      expect(current).not.toBeNull();
+      expect(current?.sessionId).toBe('session-1');
+      expect(current?.videoPath).toBe('/tmp/video.mp4');
+      expect(current?.process).toBe(mockProcess);
+    });
+
+    it('returns null after stop', () => {
+      recording.start('session-1', mockProcess, '/tmp/video.mp4');
+      recording.stop();
+      expect(recording.getCurrent()).toBeNull();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('allows starting a new recording after stopping', () => {
+      recording.start('session-1', mockProcess, '/tmp/video1.mp4');
+      recording.stop();
+
+      const newProcess = { pid: 5678 } as unknown as ChildProcess;
+      recording.start('session-2', newProcess, '/tmp/video2.mp4');
+
+      expect(recording.isRecording()).toBe(true);
+      expect(recording.getCurrent()?.sessionId).toBe('session-2');
+    });
+  });
+});

--- a/tests/unit/mcp/analyzeScreenshot.test.ts
+++ b/tests/unit/mcp/analyzeScreenshot.test.ts
@@ -1,0 +1,175 @@
+/**
+ * analyzeScreenshot Tool Unit Tests
+ *
+ * Tests the analyze_screenshot MCP tool handler:
+ * - Registers tool with correct name
+ * - Captures screenshot to temp path
+ * - Optimizes the captured image
+ * - Returns base64 image content
+ * - Includes display and timestamp in description
+ * - Includes question in description when provided
+ * - Cleans up temp file after completion
+ * - Cleans up temp file on error
+ * - Returns isError on capture failure
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const { mockCapture, mockOptimize, mockReadFile, mockUnlink } = vi.hoisted(() => ({
+  mockCapture: vi.fn(),
+  mockOptimize: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockUnlink: vi.fn(),
+}));
+
+vi.mock('../../../src/mcp/capture/ScreenCapture.js', () => ({
+  capture: mockCapture,
+}));
+
+vi.mock('../../../src/mcp/utils/ImageOptimizer.js', () => ({
+  optimize: mockOptimize,
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: mockReadFile,
+  unlink: mockUnlink,
+}));
+
+vi.mock('os', () => ({
+  tmpdir: () => '/tmp',
+}));
+
+vi.mock('crypto', () => ({
+  randomUUID: () => 'test-uuid-1234',
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    number: () => ({ optional: () => ({ default: () => ({ describe: () => ({}) }) }) }),
+    string: () => ({ optional: () => ({ describe: () => ({}) }) }),
+  },
+}));
+
+import { register } from '../../../src/mcp/tools/analyzeScreenshot.js';
+
+describe('analyzeScreenshot tool', () => {
+  let toolHandler: Function;
+  let mockServer: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockServer = {
+      tool: vi.fn((_name: string, _desc: string, _schema: any, handler: Function) => {
+        toolHandler = handler;
+      }),
+    };
+
+    mockCapture.mockResolvedValue('/tmp/markupr-mcp-screenshot-test-uuid-1234.png');
+    mockOptimize.mockResolvedValue('/tmp/markupr-mcp-screenshot-test-uuid-1234.png');
+    mockReadFile.mockResolvedValue(Buffer.from('fake-image-data'));
+    mockUnlink.mockResolvedValue(undefined);
+
+    register(mockServer);
+  });
+
+  it('registers with correct tool name', () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'analyze_screenshot',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('captures screenshot with display param', async () => {
+    await toolHandler({ display: 2, question: undefined });
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ display: 2 }),
+    );
+  });
+
+  it('optimizes the captured image', async () => {
+    await toolHandler({ display: 1, question: undefined });
+
+    expect(mockOptimize).toHaveBeenCalledWith(
+      expect.stringContaining('markupr-mcp-screenshot'),
+    );
+  });
+
+  it('returns image content as base64', async () => {
+    const result = await toolHandler({ display: 1, question: undefined });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0].type).toBe('image');
+    expect(result.content[0].mimeType).toBe('image/png');
+    expect(result.content[0].data).toBe(Buffer.from('fake-image-data').toString('base64'));
+  });
+
+  it('returns text content with timestamp', async () => {
+    const result = await toolHandler({ display: 1, question: undefined });
+
+    expect(result.content[1].type).toBe('text');
+    expect(result.content[1].text).toContain('Screenshot of display 1');
+    expect(result.content[1].text).toContain('captured at');
+  });
+
+  it('includes question in description when provided', async () => {
+    const result = await toolHandler({ display: 1, question: 'What color is the button?' });
+
+    expect(result.content[1].text).toContain('Question: What color is the button?');
+  });
+
+  it('omits question from description when not provided', async () => {
+    const result = await toolHandler({ display: 1, question: undefined });
+
+    expect(result.content[1].text).not.toContain('Question:');
+  });
+
+  it('cleans up temp file after success', async () => {
+    await toolHandler({ display: 1, question: undefined });
+
+    expect(mockUnlink).toHaveBeenCalledWith(
+      expect.stringContaining('markupr-mcp-screenshot'),
+    );
+  });
+
+  it('cleans up temp file even on error', async () => {
+    mockCapture.mockRejectedValue(new Error('Permission denied'));
+
+    await toolHandler({ display: 1, question: undefined });
+
+    expect(mockUnlink).toHaveBeenCalled();
+  });
+
+  it('returns isError on capture failure', async () => {
+    mockCapture.mockRejectedValue(new Error('Permission denied'));
+
+    const result = await toolHandler({ display: 1, question: undefined });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Permission denied');
+  });
+
+  it('returns isError on optimize failure', async () => {
+    mockOptimize.mockRejectedValue(new Error('sharp failed'));
+
+    const result = await toolHandler({ display: 1, question: undefined });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('sharp failed');
+  });
+});

--- a/tests/unit/mcp/analyzeVideo.test.ts
+++ b/tests/unit/mcp/analyzeVideo.test.ts
@@ -1,0 +1,250 @@
+/**
+ * analyzeVideo Tool Unit Tests
+ *
+ * Tests the analyze_video MCP tool handler:
+ * - Registers tool with correct name
+ * - Validates video file exists via stat
+ * - Returns isError when video file not found
+ * - Returns isError when video file is empty
+ * - Validates optional audio file
+ * - Creates CLIPipeline with correct options
+ * - Passes audioPath to pipeline when provided
+ * - Returns pipeline summary
+ * - Returns isError on pipeline failure
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const {
+  mockStat,
+  mockPipelineRun,
+  mockCLIPipeline,
+  mockCreate,
+  mockGetSessionDir,
+  mockUpdate,
+} = vi.hoisted(() => {
+  const pipelineRun = vi.fn();
+  return {
+    mockStat: vi.fn(),
+    mockPipelineRun: pipelineRun,
+    mockCLIPipeline: vi.fn().mockImplementation(() => ({ run: pipelineRun })),
+    mockCreate: vi.fn(),
+    mockGetSessionDir: vi.fn(),
+    mockUpdate: vi.fn(),
+  };
+});
+
+vi.mock('fs/promises', () => ({
+  stat: mockStat,
+}));
+
+vi.mock('../../../src/cli/CLIPipeline.js', () => ({
+  CLIPipeline: mockCLIPipeline,
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('../../../src/mcp/session/SessionStore.js', () => ({
+  sessionStore: {
+    create: (...args: unknown[]) => mockCreate(...args),
+    getSessionDir: (...args: unknown[]) => mockGetSessionDir(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    string: () => ({
+      describe: () => ({}),
+      optional: () => ({ describe: () => ({}) }),
+    }),
+    boolean: () => ({ optional: () => ({ default: () => ({ describe: () => ({}) }) }) }),
+  },
+}));
+
+import { register } from '../../../src/mcp/tools/analyzeVideo.js';
+
+describe('analyzeVideo tool', () => {
+  let toolHandler: Function;
+  let mockServer: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockServer = {
+      tool: vi.fn((_name: string, _desc: string, _schema: any, handler: Function) => {
+        toolHandler = handler;
+      }),
+    };
+
+    mockCreate.mockResolvedValue({ id: 'mcp-20260214-120000' });
+    mockGetSessionDir.mockReturnValue('/tmp/sessions/mcp-20260214-120000');
+    mockUpdate.mockResolvedValue(undefined);
+    mockPipelineRun.mockResolvedValue({
+      outputPath: '/tmp/sessions/mcp-20260214-120000/feedback-report.md',
+      transcriptSegments: 8,
+      extractedFrames: 4,
+      durationSeconds: 12.5,
+    });
+
+    register(mockServer);
+  });
+
+  it('registers with correct tool name', () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'analyze_video',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('returns isError when video file not found', async () => {
+    mockStat.mockRejectedValue(new Error('ENOENT'));
+
+    const result = await toolHandler({
+      videoPath: '/nonexistent/video.mp4',
+      skipFrames: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Video file not found');
+  });
+
+  it('returns isError when video file is empty', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 0 });
+
+    const result = await toolHandler({
+      videoPath: '/tmp/empty.mp4',
+      skipFrames: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('empty or not a regular file');
+  });
+
+  it('returns isError when video is not a regular file', async () => {
+    mockStat.mockResolvedValue({ isFile: () => false, size: 1000 });
+
+    const result = await toolHandler({
+      videoPath: '/tmp/not-a-file',
+      skipFrames: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('empty or not a regular file');
+  });
+
+  it('validates audio file when provided', async () => {
+    mockStat
+      .mockResolvedValueOnce({ isFile: () => true, size: 5000 }) // video
+      .mockRejectedValueOnce(new Error('ENOENT')); // audio
+
+    const result = await toolHandler({
+      videoPath: '/tmp/video.mp4',
+      audioPath: '/nonexistent/audio.wav',
+      skipFrames: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Audio file not found');
+  });
+
+  it('returns isError when audio file is empty', async () => {
+    mockStat
+      .mockResolvedValueOnce({ isFile: () => true, size: 5000 }) // video
+      .mockResolvedValueOnce({ isFile: () => true, size: 0 }); // audio
+
+    const result = await toolHandler({
+      videoPath: '/tmp/video.mp4',
+      audioPath: '/tmp/empty.wav',
+      skipFrames: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Audio file is empty');
+  });
+
+  it('creates CLIPipeline with correct options for valid video', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 5000 });
+
+    await toolHandler({
+      videoPath: '/tmp/video.mp4',
+      skipFrames: true,
+    });
+
+    expect(mockCLIPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        videoPath: '/tmp/video.mp4',
+        skipFrames: true,
+        verbose: false,
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('passes audioPath to pipeline when provided', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 5000 });
+
+    await toolHandler({
+      videoPath: '/tmp/video.mp4',
+      audioPath: '/tmp/audio.wav',
+      skipFrames: false,
+    });
+
+    expect(mockCLIPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audioPath: '/tmp/audio.wav',
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('returns pipeline summary on success', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 5000 });
+
+    const result = await toolHandler({
+      videoPath: '/tmp/video.mp4',
+      skipFrames: false,
+    });
+
+    expect(result.content[0].text).toContain('Video analysis complete');
+    expect(result.content[0].text).toContain('Transcript segments: 8');
+    expect(result.content[0].text).toContain('Extracted frames: 4');
+    expect(result.content[0].text).toContain('OUTPUT:');
+  });
+
+  it('updates session with results on success', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 5000 });
+
+    await toolHandler({ videoPath: '/tmp/video.mp4', skipFrames: false });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'mcp-20260214-120000',
+      expect.objectContaining({ status: 'complete' }),
+    );
+  });
+
+  it('returns isError on pipeline failure', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 5000 });
+    mockPipelineRun.mockRejectedValue(new Error('Pipeline crashed'));
+
+    const result = await toolHandler({
+      videoPath: '/tmp/video.mp4',
+      skipFrames: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Pipeline crashed');
+  });
+});

--- a/tests/unit/mcp/audioCapture.test.ts
+++ b/tests/unit/mcp/audioCapture.test.ts
@@ -1,0 +1,183 @@
+/**
+ * AudioCapture Unit Tests
+ *
+ * Tests the ffmpeg avfoundation audio recording wrapper:
+ * - Correct ffmpeg arguments (format, sample rate, channels, codec, duration)
+ * - Default device is "default"
+ * - Custom device selection
+ * - Duration included in args
+ * - Timeout calculation (duration + 10 seconds)
+ * - Error on permission denied
+ * - Error on empty output file
+ * - Error when output file is missing
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const { mockExecFileCb, mockStat } = vi.hoisted(() => ({
+  mockExecFileCb: vi.fn(),
+  mockStat: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFile: mockExecFileCb,
+}));
+
+vi.mock('fs/promises', () => ({
+  stat: mockStat,
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+import { record } from '../../../src/mcp/capture/AudioCapture.js';
+
+describe('AudioCapture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls ffmpeg with correct audio recording args', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 50000 });
+
+    await record({ duration: 10, outputPath: '/tmp/audio.wav' });
+
+    expect(mockExecFileCb).toHaveBeenCalledWith(
+      'ffmpeg',
+      expect.arrayContaining([
+        '-f', 'avfoundation',
+        '-i', ':default',
+        '-ar', '16000',
+        '-ac', '1',
+        '-acodec', 'pcm_f32le',
+        '-t', '10',
+        '-y',
+      ]),
+      expect.objectContaining({
+        env: expect.any(Object),
+        timeout: 20000, // (10 + 10) * 1000
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('uses custom device when specified', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 50000 });
+
+    await record({ duration: 5, outputPath: '/tmp/audio.wav', device: 'External Mic' });
+
+    expect(mockExecFileCb).toHaveBeenCalledWith(
+      'ffmpeg',
+      expect.arrayContaining(['-i', ':External Mic']),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('uses default device when none specified', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 50000 });
+
+    await record({ duration: 5, outputPath: '/tmp/audio.wav' });
+
+    expect(mockExecFileCb).toHaveBeenCalledWith(
+      'ffmpeg',
+      expect.arrayContaining(['-i', ':default']),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('returns the output path on success', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 50000 });
+
+    const result = await record({ duration: 5, outputPath: '/tmp/audio.wav' });
+    expect(result).toContain('audio.wav');
+  });
+
+  it('throws permission error when ffmpeg reports permission denied', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(new Error('permission not granted for audio'));
+      },
+    );
+
+    await expect(
+      record({ duration: 5, outputPath: '/tmp/audio.wav' }),
+    ).rejects.toThrow('Microphone access denied');
+  });
+
+  it('throws generic error for non-permission ffmpeg failures', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(new Error('ffmpeg crashed'));
+      },
+    );
+
+    await expect(
+      record({ duration: 5, outputPath: '/tmp/audio.wav' }),
+    ).rejects.toThrow('Audio recording failed');
+  });
+
+  it('throws when output file does not exist', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(
+      record({ duration: 5, outputPath: '/tmp/audio.wav' }),
+    ).rejects.toThrow('Audio file not created');
+  });
+
+  it('throws when output file is empty', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 0 });
+
+    await expect(
+      record({ duration: 5, outputPath: '/tmp/audio.wav' }),
+    ).rejects.toThrow('file is empty');
+  });
+
+  it('sets timeout based on duration', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], opts: { timeout: number }, cb: Function) => {
+        expect(opts.timeout).toBe(40000); // (30 + 10) * 1000
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 50000 });
+
+    await record({ duration: 30, outputPath: '/tmp/audio.wav' });
+  });
+});

--- a/tests/unit/mcp/captureScreenshot.test.ts
+++ b/tests/unit/mcp/captureScreenshot.test.ts
@@ -1,0 +1,158 @@
+/**
+ * captureScreenshot Tool Unit Tests
+ *
+ * Tests the capture_screenshot MCP tool handler:
+ * - Registers tool with correct name
+ * - Calls ScreenCapture.capture with display param
+ * - Calls ImageOptimizer.optimize when optimize=true
+ * - Skips optimization when optimize=false
+ * - Creates session via SessionStore
+ * - Returns markdown image reference
+ * - Returns isError on capture failure
+ * - Sequential filename generation (screenshot-001, screenshot-002, etc.)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const { mockCapture, mockOptimize, mockReaddir } = vi.hoisted(() => ({
+  mockCapture: vi.fn(),
+  mockOptimize: vi.fn(),
+  mockReaddir: vi.fn(),
+}));
+
+vi.mock('../../../src/mcp/capture/ScreenCapture.js', () => ({
+  capture: mockCapture,
+}));
+
+vi.mock('../../../src/mcp/utils/ImageOptimizer.js', () => ({
+  optimize: mockOptimize,
+}));
+
+vi.mock('fs/promises', () => ({
+  readdir: mockReaddir,
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+// Mock SessionStore
+const mockCreate = vi.fn();
+const mockGetSessionDir = vi.fn();
+
+vi.mock('../../../src/mcp/session/SessionStore.js', () => ({
+  sessionStore: {
+    create: (...args: unknown[]) => mockCreate(...args),
+    getSessionDir: (...args: unknown[]) => mockGetSessionDir(...args),
+  },
+}));
+
+// Mock McpServer
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    string: () => ({ optional: () => ({ describe: () => ({}) }) }),
+    number: () => ({ optional: () => ({ default: () => ({ describe: () => ({}) }) }) }),
+    boolean: () => ({ optional: () => ({ default: () => ({ describe: () => ({}) }) }) }),
+  },
+}));
+
+import { register } from '../../../src/mcp/tools/captureScreenshot.js';
+
+describe('captureScreenshot tool', () => {
+  let toolHandler: Function;
+  let mockServer: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockServer = {
+      tool: vi.fn((_name: string, _desc: string, _schema: any, handler: Function) => {
+        toolHandler = handler;
+      }),
+    };
+
+    mockCreate.mockResolvedValue({ id: 'mcp-20260214-120000' });
+    mockGetSessionDir.mockReturnValue('/tmp/sessions/mcp-20260214-120000');
+    mockCapture.mockResolvedValue('/tmp/sessions/mcp-20260214-120000/screenshots/screenshot-001.png');
+    mockOptimize.mockResolvedValue('/tmp/sessions/mcp-20260214-120000/screenshots/screenshot-001.png');
+    mockReaddir.mockResolvedValue([]);
+
+    register(mockServer);
+  });
+
+  it('registers with correct tool name', () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'capture_screenshot',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('creates a session on capture', async () => {
+    await toolHandler({ label: 'test', display: 1, optimize: true });
+    expect(mockCreate).toHaveBeenCalledWith('test');
+  });
+
+  it('calls ScreenCapture.capture with display param', async () => {
+    await toolHandler({ label: 'test', display: 2, optimize: true });
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ display: 2 }),
+    );
+  });
+
+  it('calls ImageOptimizer.optimize when optimize is true', async () => {
+    await toolHandler({ label: 'test', display: 1, optimize: true });
+    expect(mockOptimize).toHaveBeenCalled();
+  });
+
+  it('skips optimization when optimize is false', async () => {
+    await toolHandler({ label: 'test', display: 1, optimize: false });
+    expect(mockOptimize).not.toHaveBeenCalled();
+  });
+
+  it('returns text content with markdown image reference', async () => {
+    const result = await toolHandler({ label: 'my label', display: 1, optimize: true });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Screenshot saved:');
+    expect(result.content[0].text).toContain('![my label]');
+  });
+
+  it('uses filename as label when no label provided', async () => {
+    const result = await toolHandler({ label: undefined, display: 1, optimize: true });
+
+    expect(result.content[0].text).toContain('![screenshot-001.png]');
+  });
+
+  it('generates sequential filenames', async () => {
+    mockReaddir.mockResolvedValue(['screenshot-001.png', 'screenshot-002.png']);
+
+    await toolHandler({ label: 'test', display: 1, optimize: true });
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputPath: expect.stringContaining('screenshot-003.png'),
+      }),
+    );
+  });
+
+  it('returns isError on capture failure', async () => {
+    mockCapture.mockRejectedValue(new Error('Permission denied'));
+
+    const result = await toolHandler({ label: 'test', display: 1, optimize: true });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Permission denied');
+  });
+});

--- a/tests/unit/mcp/captureWithVoice.test.ts
+++ b/tests/unit/mcp/captureWithVoice.test.ts
@@ -1,0 +1,184 @@
+/**
+ * captureWithVoice Tool Unit Tests
+ *
+ * Tests the capture_with_voice MCP tool handler:
+ * - Registers tool with correct name
+ * - Calls ScreenRecorder.record with duration
+ * - Creates a CLIPipeline instance and runs it
+ * - Updates session with results
+ * - Returns pipeline summary
+ * - Returns isError on failure
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const {
+  mockRecord,
+  mockPipelineRun,
+  mockCLIPipeline,
+  mockCreate,
+  mockGetSessionDir,
+  mockUpdate,
+} = vi.hoisted(() => {
+  const pipelineRun = vi.fn();
+  return {
+    mockRecord: vi.fn(),
+    mockPipelineRun: pipelineRun,
+    mockCLIPipeline: vi.fn().mockImplementation(() => ({ run: pipelineRun })),
+    mockCreate: vi.fn(),
+    mockGetSessionDir: vi.fn(),
+    mockUpdate: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/mcp/capture/ScreenRecorder.js', () => ({
+  record: mockRecord,
+}));
+
+vi.mock('../../../src/cli/CLIPipeline.js', () => ({
+  CLIPipeline: mockCLIPipeline,
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('../../../src/mcp/session/SessionStore.js', () => ({
+  sessionStore: {
+    create: (...args: unknown[]) => mockCreate(...args),
+    getSessionDir: (...args: unknown[]) => mockGetSessionDir(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    string: () => ({ optional: () => ({ describe: () => ({}) }) }),
+    number: () => ({ min: () => ({ max: () => ({ describe: () => ({}) }) }) }),
+    boolean: () => ({ optional: () => ({ default: () => ({ describe: () => ({}) }) }) }),
+  },
+}));
+
+import { register } from '../../../src/mcp/tools/captureWithVoice.js';
+
+describe('captureWithVoice tool', () => {
+  let toolHandler: Function;
+  let mockServer: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockServer = {
+      tool: vi.fn((_name: string, _desc: string, _schema: any, handler: Function) => {
+        toolHandler = handler;
+      }),
+    };
+
+    mockCreate.mockResolvedValue({ id: 'mcp-20260214-120000' });
+    mockGetSessionDir.mockReturnValue('/tmp/sessions/mcp-20260214-120000');
+    mockUpdate.mockResolvedValue(undefined);
+    mockRecord.mockResolvedValue('/tmp/sessions/mcp-20260214-120000/recording.mp4');
+    mockPipelineRun.mockResolvedValue({
+      outputPath: '/tmp/sessions/mcp-20260214-120000/feedback-report.md',
+      transcriptSegments: 5,
+      extractedFrames: 3,
+      durationSeconds: 8.2,
+    });
+
+    register(mockServer);
+  });
+
+  it('registers with correct tool name', () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'capture_with_voice',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('calls ScreenRecorder.record with specified duration', async () => {
+    await toolHandler({ duration: 30, skipFrames: false });
+
+    expect(mockRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ duration: 30 }),
+    );
+  });
+
+  it('creates a CLIPipeline with correct options', async () => {
+    await toolHandler({ duration: 30, skipFrames: true });
+
+    expect(mockCLIPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skipFrames: true,
+        verbose: false,
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('runs the pipeline', async () => {
+    await toolHandler({ duration: 30, skipFrames: false });
+    expect(mockPipelineRun).toHaveBeenCalled();
+  });
+
+  it('updates session with results on success', async () => {
+    await toolHandler({ duration: 30, skipFrames: false });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'mcp-20260214-120000',
+      expect.objectContaining({
+        status: 'complete',
+        reportPath: expect.stringContaining('feedback-report.md'),
+      }),
+    );
+  });
+
+  it('returns pipeline summary in response', async () => {
+    const result = await toolHandler({ duration: 30, skipFrames: false });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toContain('Recording complete: 30 seconds');
+    expect(result.content[0].text).toContain('Transcript segments: 5');
+    expect(result.content[0].text).toContain('Extracted frames: 3');
+    expect(result.content[0].text).toContain('Processing time: 8.2s');
+    expect(result.content[0].text).toContain('OUTPUT:');
+  });
+
+  it('uses custom outputDir when provided', async () => {
+    await toolHandler({ duration: 10, outputDir: '/custom/output', skipFrames: false });
+
+    expect(mockCLIPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputDir: '/custom/output',
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('returns isError on recording failure', async () => {
+    mockRecord.mockRejectedValue(new Error('ffmpeg not found'));
+
+    const result = await toolHandler({ duration: 30, skipFrames: false });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('ffmpeg not found');
+  });
+
+  it('returns isError on pipeline failure', async () => {
+    mockPipelineRun.mockRejectedValue(new Error('Whisper failed'));
+
+    const result = await toolHandler({ duration: 30, skipFrames: false });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Whisper failed');
+  });
+});

--- a/tests/unit/mcp/deviceDetector.test.ts
+++ b/tests/unit/mcp/deviceDetector.test.ts
@@ -1,0 +1,161 @@
+/**
+ * DeviceDetector Unit Tests
+ *
+ * Tests parsing of ffmpeg avfoundation device list output:
+ * - Correct parsing of video devices
+ * - Correct parsing of audio devices
+ * - Handling of mixed/interleaved output
+ * - Empty device lists
+ * - Malformed output handling
+ * - Error when ffmpeg doesn't return AVFoundation output
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const { mockExecFileCb } = vi.hoisted(() => ({
+  mockExecFileCb: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFile: mockExecFileCb,
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+import { detectDevices, parseDeviceList } from '../../../src/mcp/capture/DeviceDetector.js';
+
+describe('DeviceDetector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('parseDeviceList', () => {
+    const SAMPLE_OUTPUT = [
+      '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation video devices:',
+      '[AVFoundation indev @ 0x7f8b8c000000] [0] Capture screen 0',
+      '[AVFoundation indev @ 0x7f8b8c000000] [1] Capture screen 1',
+      '[AVFoundation indev @ 0x7f8b8c000000] [2] FaceTime HD Camera',
+      '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation audio devices:',
+      '[AVFoundation indev @ 0x7f8b8c000000] [0] MacBook Pro Microphone',
+      '[AVFoundation indev @ 0x7f8b8c000000] [1] External Microphone',
+    ].join('\n');
+
+    it('parses video devices correctly', () => {
+      const result = parseDeviceList(SAMPLE_OUTPUT);
+      expect(result.video).toHaveLength(3);
+      expect(result.video[0]).toEqual({ index: 0, name: 'Capture screen 0' });
+      expect(result.video[1]).toEqual({ index: 1, name: 'Capture screen 1' });
+      expect(result.video[2]).toEqual({ index: 2, name: 'FaceTime HD Camera' });
+    });
+
+    it('parses audio devices correctly', () => {
+      const result = parseDeviceList(SAMPLE_OUTPUT);
+      expect(result.audio).toHaveLength(2);
+      expect(result.audio[0]).toEqual({ index: 0, name: 'MacBook Pro Microphone' });
+      expect(result.audio[1]).toEqual({ index: 1, name: 'External Microphone' });
+    });
+
+    it('returns empty arrays for output with no devices', () => {
+      const noDevices = [
+        '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation video devices:',
+        '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation audio devices:',
+      ].join('\n');
+
+      const result = parseDeviceList(noDevices);
+      expect(result.video).toHaveLength(0);
+      expect(result.audio).toHaveLength(0);
+    });
+
+    it('returns empty arrays for completely empty input', () => {
+      const result = parseDeviceList('');
+      expect(result.video).toHaveLength(0);
+      expect(result.audio).toHaveLength(0);
+    });
+
+    it('handles output with only video devices', () => {
+      const videoOnly = [
+        '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation video devices:',
+        '[AVFoundation indev @ 0x7f8b8c000000] [0] Capture screen 0',
+      ].join('\n');
+
+      const result = parseDeviceList(videoOnly);
+      expect(result.video).toHaveLength(1);
+      expect(result.audio).toHaveLength(0);
+    });
+
+    it('handles output with only audio devices', () => {
+      const audioOnly = [
+        '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation audio devices:',
+        '[AVFoundation indev @ 0x7f8b8c000000] [0] Built-in Microphone',
+      ].join('\n');
+
+      const result = parseDeviceList(audioOnly);
+      expect(result.video).toHaveLength(0);
+      expect(result.audio).toHaveLength(1);
+      expect(result.audio[0]).toEqual({ index: 0, name: 'Built-in Microphone' });
+    });
+
+    it('ignores non-device lines in output', () => {
+      const withNoise = [
+        'ffmpeg version 6.1 Copyright (c) 2000-2023 the FFmpeg developers',
+        '  built with Apple clang version 15.0.0',
+        '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation video devices:',
+        '[AVFoundation indev @ 0x7f8b8c000000] [0] Screen 0',
+        'some random noise line',
+        '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation audio devices:',
+        '[AVFoundation indev @ 0x7f8b8c000000] [0] Mic',
+      ].join('\n');
+
+      const result = parseDeviceList(withNoise);
+      expect(result.video).toHaveLength(1);
+      expect(result.audio).toHaveLength(1);
+    });
+
+    it('trims device names', () => {
+      const withSpaces = [
+        '[AVFoundation indev @ 0x7f8b8c000000] AVFoundation video devices:',
+        '[AVFoundation indev @ 0x7f8b8c000000] [0]   Capture screen 0  ',
+      ].join('\n');
+
+      const result = parseDeviceList(withSpaces);
+      expect(result.video[0].name).toBe('Capture screen 0');
+    });
+  });
+
+  describe('detectDevices', () => {
+    it('rejects when ffmpeg does not return AVFoundation output', async () => {
+      mockExecFileCb.mockImplementation(
+        (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+          cb(null, '', 'no relevant output');
+        },
+      );
+
+      await expect(detectDevices()).rejects.toThrow('AVFoundation');
+    });
+
+    it('resolves with parsed devices on valid output', async () => {
+      const validOutput = [
+        '[AVFoundation indev @ 0x7f] AVFoundation video devices:',
+        '[AVFoundation indev @ 0x7f] [0] Screen',
+        '[AVFoundation indev @ 0x7f] AVFoundation audio devices:',
+        '[AVFoundation indev @ 0x7f] [0] Mic',
+      ].join('\n');
+
+      mockExecFileCb.mockImplementation(
+        (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+          cb(new Error('exit 1'), '', validOutput);
+        },
+      );
+
+      const result = await detectDevices();
+      expect(result.video).toHaveLength(1);
+      expect(result.audio).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/mcp/imageOptimizer.test.ts
+++ b/tests/unit/mcp/imageOptimizer.test.ts
@@ -1,0 +1,160 @@
+/**
+ * ImageOptimizer Unit Tests
+ *
+ * Tests the sharp-based image optimization:
+ * - Default max width (1920) and quality (85)
+ * - Custom max width and quality
+ * - Resize triggered when image exceeds max width
+ * - No resize when image is within max width
+ * - JPEG output for .jpg/.jpeg extensions
+ * - PNG output for .png and other extensions
+ * - Output path defaults to input path when not specified
+ * - Custom output path
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const { mockSharpInstance, mockSharp } = vi.hoisted(() => {
+  const instance = {
+    metadata: vi.fn(),
+    resize: vi.fn(),
+    png: vi.fn(),
+    jpeg: vi.fn(),
+    toFile: vi.fn(),
+  };
+  // Chain returns self
+  instance.resize.mockReturnValue(instance);
+  instance.png.mockReturnValue(instance);
+  instance.jpeg.mockReturnValue(instance);
+  instance.toFile.mockResolvedValue({ width: 1920, height: 1080, size: 102400 });
+
+  return {
+    mockSharpInstance: instance,
+    mockSharp: vi.fn(() => instance),
+  };
+});
+
+vi.mock('sharp', () => ({
+  default: mockSharp,
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+import { optimize } from '../../../src/mcp/utils/ImageOptimizer.js';
+
+describe('ImageOptimizer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset chain returns after clearAllMocks
+    mockSharpInstance.resize.mockReturnValue(mockSharpInstance);
+    mockSharpInstance.png.mockReturnValue(mockSharpInstance);
+    mockSharpInstance.jpeg.mockReturnValue(mockSharpInstance);
+    mockSharpInstance.toFile.mockResolvedValue({ width: 1920, height: 1080, size: 102400 });
+  });
+
+  it('resizes images wider than default max width (1920)', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 2560, height: 1440 });
+
+    await optimize('/tmp/input.png');
+
+    expect(mockSharpInstance.resize).toHaveBeenCalledWith({
+      width: 1920,
+      withoutEnlargement: true,
+    });
+  });
+
+  it('does not resize images within default max width', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 1200, height: 800 });
+
+    await optimize('/tmp/input.png');
+
+    expect(mockSharpInstance.resize).not.toHaveBeenCalled();
+  });
+
+  it('uses custom max width when specified', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 1500, height: 900 });
+
+    await optimize('/tmp/input.png', undefined, { maxWidth: 1280 });
+
+    expect(mockSharpInstance.resize).toHaveBeenCalledWith({
+      width: 1280,
+      withoutEnlargement: true,
+    });
+  });
+
+  it('applies PNG format for .png files', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 800, height: 600 });
+
+    await optimize('/tmp/input.png');
+
+    expect(mockSharpInstance.png).toHaveBeenCalledWith({ quality: 85 });
+    expect(mockSharpInstance.jpeg).not.toHaveBeenCalled();
+  });
+
+  it('applies JPEG format for .jpg files', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 800, height: 600 });
+
+    await optimize('/tmp/input.jpg');
+
+    expect(mockSharpInstance.jpeg).toHaveBeenCalledWith({ quality: 85 });
+    expect(mockSharpInstance.png).not.toHaveBeenCalled();
+  });
+
+  it('applies JPEG format for .jpeg files', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 800, height: 600 });
+
+    await optimize('/tmp/input.jpeg');
+
+    expect(mockSharpInstance.jpeg).toHaveBeenCalledWith({ quality: 85 });
+  });
+
+  it('uses custom quality when specified', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 800, height: 600 });
+
+    await optimize('/tmp/input.png', undefined, { quality: 60 });
+
+    expect(mockSharpInstance.png).toHaveBeenCalledWith({ quality: 60 });
+  });
+
+  it('overwrites input when no output path is specified', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 800, height: 600 });
+
+    await optimize('/tmp/input.png');
+
+    expect(mockSharpInstance.toFile).toHaveBeenCalledWith(
+      expect.stringContaining('input.png'),
+    );
+  });
+
+  it('writes to custom output path when specified', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 800, height: 600 });
+
+    await optimize('/tmp/input.png', '/tmp/output.png');
+
+    expect(mockSharpInstance.toFile).toHaveBeenCalledWith(
+      expect.stringContaining('output.png'),
+    );
+  });
+
+  it('returns the output path', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 800, height: 600 });
+
+    const result = await optimize('/tmp/input.png', '/tmp/output.png');
+
+    expect(result).toContain('output.png');
+  });
+
+  it('caps quality at 100 for PNG', async () => {
+    mockSharpInstance.metadata.mockResolvedValue({ width: 800, height: 600 });
+
+    await optimize('/tmp/input.png', undefined, { quality: 150 });
+
+    expect(mockSharpInstance.png).toHaveBeenCalledWith({ quality: 100 });
+  });
+});

--- a/tests/unit/mcp/screenCapture.test.ts
+++ b/tests/unit/mcp/screenCapture.test.ts
@@ -1,0 +1,141 @@
+/**
+ * ScreenCapture Unit Tests
+ *
+ * Tests the macOS screencapture CLI wrapper:
+ * - Correct command arguments (-x, -D{display}, outputPath)
+ * - Default display is 1
+ * - Custom display number
+ * - Error when screencapture command fails
+ * - Error when output file is missing
+ * - Error when output file is empty (permission denied)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const { mockExecFileCb, mockStat } = vi.hoisted(() => ({
+  mockExecFileCb: vi.fn(),
+  mockStat: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFile: mockExecFileCb,
+}));
+
+vi.mock('fs/promises', () => ({
+  stat: mockStat,
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+import { capture } from '../../../src/mcp/capture/ScreenCapture.js';
+
+describe('ScreenCapture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls screencapture with correct args for default display', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 5000 });
+
+    await capture({ outputPath: '/tmp/test.png' });
+
+    expect(mockExecFileCb).toHaveBeenCalledWith(
+      'screencapture',
+      ['-x', '-D1', expect.stringContaining('test.png')],
+      expect.objectContaining({ env: expect.any(Object) }),
+      expect.any(Function),
+    );
+  });
+
+  it('uses display number from options', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 5000 });
+
+    await capture({ outputPath: '/tmp/test.png', display: 2 });
+
+    expect(mockExecFileCb).toHaveBeenCalledWith(
+      'screencapture',
+      expect.arrayContaining(['-D2']),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('returns the resolved output path on success', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 12345 });
+
+    const result = await capture({ outputPath: '/tmp/test.png' });
+    expect(result).toContain('test.png');
+  });
+
+  it('throws when screencapture command fails', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(new Error('command not found'));
+      },
+    );
+
+    await expect(capture({ outputPath: '/tmp/test.png' })).rejects.toThrow(
+      'screencapture failed',
+    );
+  });
+
+  it('throws when output file does not exist', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(capture({ outputPath: '/tmp/test.png' })).rejects.toThrow(
+      'Screenshot file not created',
+    );
+  });
+
+  it('throws when output file is empty (permission denied)', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => true, size: 0 });
+
+    await expect(capture({ outputPath: '/tmp/test.png' })).rejects.toThrow(
+      'file is empty',
+    );
+  });
+
+  it('throws when stat returns non-file entry', async () => {
+    mockExecFileCb.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: Function) => {
+        cb(null);
+      },
+    );
+    mockStat.mockResolvedValue({ isFile: () => false, size: 100 });
+
+    await expect(capture({ outputPath: '/tmp/test.png' })).rejects.toThrow(
+      'file is empty',
+    );
+  });
+});

--- a/tests/unit/mcp/server.test.ts
+++ b/tests/unit/mcp/server.test.ts
@@ -1,0 +1,129 @@
+/**
+ * MCP Server Factory Unit Tests
+ *
+ * Tests that createServer():
+ * - Returns a valid McpServer instance
+ * - Registers all 6 tools
+ * - Registers resources
+ * - Uses correct server name and version
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks — vi.hoisted runs before vi.mock factory hoisting
+// =============================================================================
+
+const {
+  mockRegisterCaptureScreenshot,
+  mockRegisterCaptureWithVoice,
+  mockRegisterAnalyzeVideo,
+  mockRegisterAnalyzeScreenshot,
+  mockRegisterStartRecording,
+  mockRegisterStopRecording,
+  mockRegisterResources,
+  mockTool,
+  mockResource,
+} = vi.hoisted(() => ({
+  mockRegisterCaptureScreenshot: vi.fn(),
+  mockRegisterCaptureWithVoice: vi.fn(),
+  mockRegisterAnalyzeVideo: vi.fn(),
+  mockRegisterAnalyzeScreenshot: vi.fn(),
+  mockRegisterStartRecording: vi.fn(),
+  mockRegisterStopRecording: vi.fn(),
+  mockRegisterResources: vi.fn(),
+  mockTool: vi.fn(),
+  mockResource: vi.fn(),
+}));
+
+vi.mock('../../../src/mcp/tools/captureScreenshot.js', () => ({
+  register: mockRegisterCaptureScreenshot,
+}));
+
+vi.mock('../../../src/mcp/tools/captureWithVoice.js', () => ({
+  register: mockRegisterCaptureWithVoice,
+}));
+
+vi.mock('../../../src/mcp/tools/analyzeVideo.js', () => ({
+  register: mockRegisterAnalyzeVideo,
+}));
+
+vi.mock('../../../src/mcp/tools/analyzeScreenshot.js', () => ({
+  register: mockRegisterAnalyzeScreenshot,
+}));
+
+vi.mock('../../../src/mcp/tools/startRecording.js', () => ({
+  register: mockRegisterStartRecording,
+}));
+
+vi.mock('../../../src/mcp/tools/stopRecording.js', () => ({
+  register: mockRegisterStopRecording,
+}));
+
+vi.mock('../../../src/mcp/resources/sessionResource.js', () => ({
+  registerResources: mockRegisterResources,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn().mockImplementation((config: { name: string; version: string }) => ({
+    name: config.name,
+    version: config.version,
+    tool: mockTool,
+    resource: mockResource,
+    connect: vi.fn(),
+  })),
+}));
+
+import { createServer } from '../../../src/mcp/server.js';
+
+describe('MCP Server Factory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a server instance', () => {
+    const server = createServer();
+    expect(server).toBeDefined();
+  });
+
+  it('registers all 6 tool handlers', () => {
+    const server = createServer();
+
+    expect(mockRegisterCaptureScreenshot).toHaveBeenCalledOnce();
+    expect(mockRegisterCaptureScreenshot).toHaveBeenCalledWith(server);
+
+    expect(mockRegisterCaptureWithVoice).toHaveBeenCalledOnce();
+    expect(mockRegisterCaptureWithVoice).toHaveBeenCalledWith(server);
+
+    expect(mockRegisterAnalyzeVideo).toHaveBeenCalledOnce();
+    expect(mockRegisterAnalyzeVideo).toHaveBeenCalledWith(server);
+
+    expect(mockRegisterAnalyzeScreenshot).toHaveBeenCalledOnce();
+    expect(mockRegisterAnalyzeScreenshot).toHaveBeenCalledWith(server);
+
+    expect(mockRegisterStartRecording).toHaveBeenCalledOnce();
+    expect(mockRegisterStartRecording).toHaveBeenCalledWith(server);
+
+    expect(mockRegisterStopRecording).toHaveBeenCalledOnce();
+    expect(mockRegisterStopRecording).toHaveBeenCalledWith(server);
+  });
+
+  it('registers session resources', () => {
+    const server = createServer();
+
+    expect(mockRegisterResources).toHaveBeenCalledOnce();
+    expect(mockRegisterResources).toHaveBeenCalledWith(server);
+  });
+
+  it('uses "markupr" as the server name', () => {
+    const server = createServer();
+    expect(server).toHaveProperty('name', 'markupr');
+  });
+
+  it('sets a version string on the server', () => {
+    const server = createServer();
+    // Version may be '0.0.0-dev' in test environment (no esbuild define)
+    expect(server).toHaveProperty('version');
+    expect(typeof (server as any).version).toBe('string');
+  });
+});

--- a/tests/unit/mcp/sessionStore.test.ts
+++ b/tests/unit/mcp/sessionStore.test.ts
@@ -1,0 +1,264 @@
+/**
+ * SessionStore Unit Tests
+ *
+ * Tests the disk-persisted session lifecycle management:
+ * - Session creation with directory and metadata.json
+ * - Session ID format (mcp-YYYYMMDD-HHMMSS)
+ * - Conflict resolution (appending counter)
+ * - Session retrieval by ID
+ * - getLatest returns most recent by startTime
+ * - list returns sessions sorted by startTime descending
+ * - update merges partial data
+ * - update throws for nonexistent session
+ * - getSessionDir returns correct path
+ * - list handles missing base directory
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const { mockMkdir, mockReadFile, mockWriteFile, mockReaddir, mockAccess } = vi.hoisted(() => ({
+  mockMkdir: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockWriteFile: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockAccess: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  mkdir: mockMkdir,
+  readFile: mockReadFile,
+  writeFile: mockWriteFile,
+  readdir: mockReaddir,
+  access: mockAccess,
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+import { SessionStore } from '../../../src/mcp/session/SessionStore.js';
+
+describe('SessionStore', () => {
+  let store: SessionStore;
+  const TEST_BASE = '/tmp/test-markupr-mcp';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new SessionStore(TEST_BASE);
+    // Default: base dir exists
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    // Default: directory doesn't exist (for create conflict check)
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+  });
+
+  describe('create', () => {
+    it('creates a session with correct directory structure', async () => {
+      const session = await store.create();
+
+      // Should create base dir
+      expect(mockMkdir).toHaveBeenCalledWith(TEST_BASE, { recursive: true });
+      // Should create session dir (pattern: mcp-YYYYMMDD-HHMMSS)
+      expect(mockMkdir).toHaveBeenCalledWith(
+        expect.stringMatching(/test-markupr-mcp\/mcp-\d{8}-\d{6}$/),
+        { recursive: true },
+      );
+      // Should create screenshots subdir
+      expect(mockMkdir).toHaveBeenCalledWith(
+        expect.stringContaining('screenshots'),
+        { recursive: true },
+      );
+    });
+
+    it('writes metadata.json on creation', async () => {
+      const session = await store.create('test label');
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('metadata.json'),
+        expect.stringContaining('"label": "test label"'),
+        'utf-8',
+      );
+    });
+
+    it('returns session with recording status', async () => {
+      const session = await store.create();
+
+      expect(session.status).toBe('recording');
+      expect(session.id).toMatch(/^mcp-\d{8}-\d{6}$/);
+      expect(session.startTime).toBeTypeOf('number');
+    });
+
+    it('includes label when provided', async () => {
+      const session = await store.create('my label');
+      expect(session.label).toBe('my label');
+    });
+
+    it('handles directory conflicts by appending counter', async () => {
+      // First access check succeeds (dir exists), second fails (dir doesn't exist)
+      mockAccess
+        .mockResolvedValueOnce(undefined) // first dir exists
+        .mockRejectedValueOnce(new Error('ENOENT')); // -1 suffix doesn't exist
+
+      const session = await store.create();
+
+      expect(session.id).toMatch(/^mcp-\d{8}-\d{6}-1$/);
+    });
+  });
+
+  describe('get', () => {
+    it('returns session when metadata.json exists', async () => {
+      const mockSession = {
+        id: 'mcp-20260214-120000',
+        startTime: 1739534400000,
+        status: 'complete',
+        label: 'test',
+      };
+      mockReadFile.mockResolvedValue(JSON.stringify(mockSession));
+
+      const session = await store.get('mcp-20260214-120000');
+
+      expect(session).toEqual(mockSession);
+      expect(mockReadFile).toHaveBeenCalledWith(
+        expect.stringContaining('mcp-20260214-120000/metadata.json'),
+        'utf-8',
+      );
+    });
+
+    it('returns null when session does not exist', async () => {
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      const session = await store.get('nonexistent');
+      expect(session).toBeNull();
+    });
+  });
+
+  describe('getLatest', () => {
+    it('returns the most recent session', async () => {
+      mockAccess.mockResolvedValue(undefined);
+      mockReaddir.mockResolvedValue([
+        { name: 'mcp-20260214-100000', isDirectory: () => true },
+        { name: 'mcp-20260214-120000', isDirectory: () => true },
+      ]);
+
+      const older = { id: 'mcp-20260214-100000', startTime: 1000, status: 'complete' };
+      const newer = { id: 'mcp-20260214-120000', startTime: 2000, status: 'complete' };
+
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(older))
+        .mockResolvedValueOnce(JSON.stringify(newer));
+
+      const latest = await store.getLatest();
+      expect(latest?.id).toBe('mcp-20260214-120000');
+    });
+
+    it('returns null when no sessions exist', async () => {
+      mockAccess.mockResolvedValue(undefined);
+      mockReaddir.mockResolvedValue([]);
+
+      const latest = await store.getLatest();
+      expect(latest).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    it('returns sessions sorted by startTime descending', async () => {
+      mockAccess.mockResolvedValue(undefined);
+      mockReaddir.mockResolvedValue([
+        { name: 'mcp-20260214-100000', isDirectory: () => true },
+        { name: 'mcp-20260214-120000', isDirectory: () => true },
+        { name: 'mcp-20260214-110000', isDirectory: () => true },
+      ]);
+
+      const s1 = { id: 'mcp-20260214-100000', startTime: 1000, status: 'complete' };
+      const s2 = { id: 'mcp-20260214-120000', startTime: 3000, status: 'complete' };
+      const s3 = { id: 'mcp-20260214-110000', startTime: 2000, status: 'complete' };
+
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(s1))
+        .mockResolvedValueOnce(JSON.stringify(s2))
+        .mockResolvedValueOnce(JSON.stringify(s3));
+
+      const sessions = await store.list();
+
+      expect(sessions).toHaveLength(3);
+      expect(sessions[0].startTime).toBe(3000);
+      expect(sessions[1].startTime).toBe(2000);
+      expect(sessions[2].startTime).toBe(1000);
+    });
+
+    it('returns empty array when base dir does not exist', async () => {
+      mockAccess.mockRejectedValue(new Error('ENOENT'));
+
+      const sessions = await store.list();
+      expect(sessions).toEqual([]);
+    });
+
+    it('skips directories without valid metadata', async () => {
+      mockAccess.mockResolvedValue(undefined);
+      mockReaddir.mockResolvedValue([
+        { name: 'mcp-20260214-100000', isDirectory: () => true },
+        { name: 'invalid-dir', isDirectory: () => true },
+      ]);
+
+      const valid = { id: 'mcp-20260214-100000', startTime: 1000, status: 'complete' };
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(valid))
+        .mockRejectedValueOnce(new Error('ENOENT'));
+
+      const sessions = await store.list();
+      expect(sessions).toHaveLength(1);
+    });
+
+    it('skips non-directory entries', async () => {
+      mockAccess.mockResolvedValue(undefined);
+      mockReaddir.mockResolvedValue([
+        { name: 'some-file.txt', isDirectory: () => false },
+        { name: 'mcp-20260214-100000', isDirectory: () => true },
+      ]);
+
+      const valid = { id: 'mcp-20260214-100000', startTime: 1000, status: 'complete' };
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(valid));
+
+      const sessions = await store.list();
+      expect(sessions).toHaveLength(1);
+    });
+  });
+
+  describe('update', () => {
+    it('merges partial data into existing metadata', async () => {
+      const existing = { id: 'mcp-20260214-100000', startTime: 1000, status: 'recording' };
+      mockReadFile.mockResolvedValue(JSON.stringify(existing));
+
+      await store.update('mcp-20260214-100000', { status: 'complete', endTime: 2000 });
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('metadata.json'),
+        expect.stringContaining('"status": "complete"'),
+        'utf-8',
+      );
+      // Should also contain the original data
+      const writtenData = JSON.parse(mockWriteFile.mock.calls[0][1]);
+      expect(writtenData.startTime).toBe(1000);
+      expect(writtenData.endTime).toBe(2000);
+    });
+
+    it('throws when session does not exist', async () => {
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      await expect(store.update('nonexistent', { status: 'complete' })).rejects.toThrow(
+        'Session not found',
+      );
+    });
+  });
+
+  describe('getSessionDir', () => {
+    it('returns the correct path for a session ID', () => {
+      const dir = store.getSessionDir('mcp-20260214-120000');
+      expect(dir).toBe(`${TEST_BASE}/mcp-20260214-120000`);
+    });
+  });
+});

--- a/tests/unit/mcp/startRecording.test.ts
+++ b/tests/unit/mcp/startRecording.test.ts
@@ -1,0 +1,151 @@
+/**
+ * startRecording Tool Unit Tests
+ *
+ * Tests the start_recording MCP tool handler:
+ * - Registers tool with correct name
+ * - Returns isError when already recording
+ * - Creates session via SessionStore
+ * - Calls ScreenRecorder.start with correct output path
+ * - Tracks recording in ActiveRecording
+ * - Returns session ID in response
+ * - Returns isError on failure
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const { mockStart } = vi.hoisted(() => ({
+  mockStart: vi.fn(),
+}));
+
+vi.mock('../../../src/mcp/capture/ScreenRecorder.js', () => ({
+  start: mockStart,
+}));
+
+const mockIsRecording = vi.fn();
+const mockGetCurrent = vi.fn();
+const mockActiveStart = vi.fn();
+
+vi.mock('../../../src/mcp/session/ActiveRecording.js', () => ({
+  activeRecording: {
+    isRecording: (...args: unknown[]) => mockIsRecording(...args),
+    getCurrent: (...args: unknown[]) => mockGetCurrent(...args),
+    start: (...args: unknown[]) => mockActiveStart(...args),
+  },
+}));
+
+const mockCreate = vi.fn();
+const mockGetSessionDir = vi.fn();
+
+vi.mock('../../../src/mcp/session/SessionStore.js', () => ({
+  sessionStore: {
+    create: (...args: unknown[]) => mockCreate(...args),
+    getSessionDir: (...args: unknown[]) => mockGetSessionDir(...args),
+  },
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    string: () => ({ optional: () => ({ describe: () => ({}) }) }),
+  },
+}));
+
+import { register } from '../../../src/mcp/tools/startRecording.js';
+
+describe('startRecording tool', () => {
+  let toolHandler: Function;
+  let mockServer: any;
+  let mockProcess: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockServer = {
+      tool: vi.fn((_name: string, _desc: string, _schema: any, handler: Function) => {
+        toolHandler = handler;
+      }),
+    };
+
+    mockProcess = { pid: 1234, kill: vi.fn() };
+    mockIsRecording.mockReturnValue(false);
+    mockGetCurrent.mockReturnValue(null);
+    mockCreate.mockResolvedValue({ id: 'mcp-20260214-120000' });
+    mockGetSessionDir.mockReturnValue('/tmp/sessions/mcp-20260214-120000');
+    mockStart.mockReturnValue(mockProcess);
+
+    register(mockServer);
+  });
+
+  it('registers with correct tool name', () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'start_recording',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('returns isError when already recording', async () => {
+    mockIsRecording.mockReturnValue(true);
+    mockGetCurrent.mockReturnValue({ sessionId: 'existing-session' });
+
+    const result = await toolHandler({ label: undefined });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Recording already in progress');
+    expect(result.content[0].text).toContain('existing-session');
+  });
+
+  it('creates a session with label', async () => {
+    await toolHandler({ label: 'bug review' });
+    expect(mockCreate).toHaveBeenCalledWith('bug review');
+  });
+
+  it('calls ScreenRecorder.start with output path', async () => {
+    await toolHandler({ label: undefined });
+
+    expect(mockStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputPath: expect.stringContaining('recording.mp4'),
+      }),
+    );
+  });
+
+  it('tracks recording in ActiveRecording', async () => {
+    await toolHandler({ label: undefined });
+
+    expect(mockActiveStart).toHaveBeenCalledWith(
+      'mcp-20260214-120000',
+      mockProcess,
+      expect.stringContaining('recording.mp4'),
+    );
+  });
+
+  it('returns session ID in response', async () => {
+    const result = await toolHandler({ label: undefined });
+
+    expect(result.content[0].text).toContain('Recording started.');
+    expect(result.content[0].text).toContain('Session ID: mcp-20260214-120000');
+    expect(result.content[0].text).toContain('stop_recording');
+  });
+
+  it('returns isError on failure', async () => {
+    mockCreate.mockRejectedValue(new Error('Disk full'));
+
+    const result = await toolHandler({ label: undefined });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Disk full');
+  });
+});

--- a/tests/unit/mcp/stopRecording.test.ts
+++ b/tests/unit/mcp/stopRecording.test.ts
@@ -1,0 +1,234 @@
+/**
+ * stopRecording Tool Unit Tests
+ *
+ * Tests the stop_recording MCP tool handler:
+ * - Registers tool with correct name
+ * - Returns isError when no recording is active
+ * - Stops the ffmpeg process via ScreenRecorder.stop
+ * - Releases the ActiveRecording lock
+ * - Updates session status to processing then complete
+ * - Creates CLIPipeline and runs it
+ * - Returns pipeline summary
+ * - Returns isError on failure
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const {
+  mockStop,
+  mockPipelineRun,
+  mockCLIPipeline,
+  mockIsRecording,
+  mockGetCurrent,
+  mockActiveStop,
+  mockUpdate,
+  mockGetSessionDir,
+} = vi.hoisted(() => {
+  const pipelineRun = vi.fn();
+  return {
+    mockStop: vi.fn(),
+    mockPipelineRun: pipelineRun,
+    mockCLIPipeline: vi.fn().mockImplementation(() => ({ run: pipelineRun })),
+    mockIsRecording: vi.fn(),
+    mockGetCurrent: vi.fn(),
+    mockActiveStop: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockGetSessionDir: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/mcp/capture/ScreenRecorder.js', () => ({
+  stop: mockStop,
+}));
+
+vi.mock('../../../src/cli/CLIPipeline.js', () => ({
+  CLIPipeline: mockCLIPipeline,
+}));
+
+vi.mock('../../../src/mcp/session/ActiveRecording.js', () => ({
+  activeRecording: {
+    isRecording: (...args: unknown[]) => mockIsRecording(...args),
+    getCurrent: (...args: unknown[]) => mockGetCurrent(...args),
+    stop: (...args: unknown[]) => mockActiveStop(...args),
+  },
+}));
+
+vi.mock('../../../src/mcp/session/SessionStore.js', () => ({
+  sessionStore: {
+    update: (...args: unknown[]) => mockUpdate(...args),
+    getSessionDir: (...args: unknown[]) => mockGetSessionDir(...args),
+  },
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    string: () => ({ optional: () => ({ describe: () => ({}) }) }),
+    boolean: () => ({ optional: () => ({ default: () => ({ describe: () => ({}) }) }) }),
+  },
+}));
+
+import { register } from '../../../src/mcp/tools/stopRecording.js';
+
+describe('stopRecording tool', () => {
+  let toolHandler: Function;
+  let mockServer: any;
+  let mockProcess: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockServer = {
+      tool: vi.fn((_name: string, _desc: string, _schema: any, handler: Function) => {
+        toolHandler = handler;
+      }),
+    };
+
+    mockProcess = { pid: 1234, exitCode: null, kill: vi.fn(), once: vi.fn() };
+    mockIsRecording.mockReturnValue(true);
+    mockGetCurrent.mockReturnValue({
+      sessionId: 'mcp-20260214-120000',
+      process: mockProcess,
+      videoPath: '/tmp/sessions/mcp-20260214-120000/recording.mp4',
+    });
+    mockActiveStop.mockReturnValue({
+      sessionId: 'mcp-20260214-120000',
+      videoPath: '/tmp/sessions/mcp-20260214-120000/recording.mp4',
+    });
+    mockStop.mockResolvedValue(undefined);
+    mockUpdate.mockResolvedValue(undefined);
+    mockGetSessionDir.mockReturnValue('/tmp/sessions/mcp-20260214-120000');
+    mockPipelineRun.mockResolvedValue({
+      outputPath: '/tmp/sessions/mcp-20260214-120000/feedback-report.md',
+      transcriptSegments: 10,
+      extractedFrames: 5,
+      durationSeconds: 15.3,
+    });
+
+    register(mockServer);
+  });
+
+  it('registers with correct tool name', () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'stop_recording',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('returns isError when no recording is active', async () => {
+    mockIsRecording.mockReturnValue(false);
+
+    const result = await toolHandler({ skipFrames: false });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No recording in progress');
+  });
+
+  it('returns isError when getCurrent returns null', async () => {
+    mockIsRecording.mockReturnValue(true);
+    mockGetCurrent.mockReturnValue(null);
+
+    const result = await toolHandler({ skipFrames: false });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No recording in progress');
+  });
+
+  it('stops the ffmpeg process', async () => {
+    await toolHandler({ skipFrames: false });
+
+    expect(mockStop).toHaveBeenCalledWith(mockProcess);
+  });
+
+  it('releases the ActiveRecording lock', async () => {
+    await toolHandler({ skipFrames: false });
+
+    expect(mockActiveStop).toHaveBeenCalled();
+  });
+
+  it('updates session status to processing', async () => {
+    await toolHandler({ skipFrames: false });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'mcp-20260214-120000',
+      expect.objectContaining({ status: 'processing' }),
+    );
+  });
+
+  it('runs the pipeline on the recorded video', async () => {
+    await toolHandler({ skipFrames: false });
+
+    expect(mockCLIPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        videoPath: expect.stringContaining('recording.mp4'),
+        skipFrames: false,
+        verbose: false,
+      }),
+      expect.any(Function),
+    );
+    expect(mockPipelineRun).toHaveBeenCalled();
+  });
+
+  it('passes skipFrames to pipeline', async () => {
+    await toolHandler({ skipFrames: true });
+
+    expect(mockCLIPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({ skipFrames: true }),
+      expect.any(Function),
+    );
+  });
+
+  it('updates session with complete status and results', async () => {
+    await toolHandler({ skipFrames: false });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'mcp-20260214-120000',
+      expect.objectContaining({
+        status: 'complete',
+        reportPath: expect.stringContaining('feedback-report.md'),
+      }),
+    );
+  });
+
+  it('returns pipeline summary in response', async () => {
+    const result = await toolHandler({ skipFrames: false });
+
+    expect(result.content[0].text).toContain('Recording stopped and processed.');
+    expect(result.content[0].text).toContain('Session: mcp-20260214-120000');
+    expect(result.content[0].text).toContain('Transcript segments: 10');
+    expect(result.content[0].text).toContain('Extracted frames: 5');
+    expect(result.content[0].text).toContain('Processing time: 15.3s');
+    expect(result.content[0].text).toContain('OUTPUT:');
+  });
+
+  it('returns isError on stop failure', async () => {
+    mockStop.mockRejectedValue(new Error('SIGINT failed'));
+
+    const result = await toolHandler({ skipFrames: false });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('SIGINT failed');
+  });
+
+  it('returns isError on pipeline failure', async () => {
+    mockPipelineRun.mockRejectedValue(new Error('Transcription failed'));
+
+    const result = await toolHandler({ skipFrames: false });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Transcription failed');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a standalone MCP (Model Context Protocol) server that lets AI coding agents — Claude Code, Cursor, Windsurf — see the developer's screen and hear their voice. Runs as a headless Node.js process over stdio JSON-RPC, no Electron required.

## What's New

### 6 MCP Tools
| Tool | Description |
|------|-------------|
| `capture_screenshot` | Screenshot → optimize → markdown image reference |
| `capture_with_voice` | Record screen+voice for N seconds → full markupr pipeline → structured report |
| `analyze_video` | Process existing video → transcript + key frames + markdown |
| `analyze_screenshot` | Screenshot → return as ImageContent for AI vision analysis |
| `start_recording` | Start long-form recording, returns session ID |
| `stop_recording` | Stop recording → run pipeline → return report |

### 2 MCP Resources
- `session://latest` — metadata for the most recent session
- `session://{id}` — metadata for a specific session

### Architecture
- Headless capture via macOS `screencapture` CLI + `ffmpeg` (no Electron)
- Session management with disk persistence (`~/Documents/markupr/mcp/`)
- `sharp`-based image optimization (replaces Electron's nativeImage)
- stderr-only logging (stdout reserved for MCP JSON-RPC protocol)
- Single-recording lock for safe concurrent tool calls

### New Files
- `src/mcp/` — 19 source files (server, tools, capture, session, utils)
- `tests/unit/mcp/` — 13 test files (129 new tests)
- `scripts/build-mcp.mjs` — esbuild bundler for MCP server
- `tests/manual/test-mcp-server.sh` — manual stdio integration test
- `README-MCP.md` — full documentation with IDE setup guides
- `docs/mcp-config-example.json` — Claude Code / Cursor config example

## Verification Results

| Check | Result |
|-------|--------|
| TypeScript (`tsc --noEmit`) | 0 errors |
| Lint (`eslint`) | 0 errors (5 pre-existing warnings in renderer, not MCP) |
| Tests (`vitest run`) | 644/644 passing (39 test files) |
| Desktop build (`build:desktop`) | Success — MCP changes don't break Electron |
| MCP build (`build:mcp`) | Success → `dist/mcp/index.mjs` |
| MCP initialize (stdio) | Valid JSON-RPC response with capabilities |
| MCP tools/list (stdio) | All 6 tools registered with correct schemas |

## Setup for Reviewers

### Quick Test
```bash
npm run build:mcp
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | node dist/mcp/index.mjs 2>/dev/null
```

### Claude Code Integration
Add to `~/.claude/settings.json`:
```json
{
  "mcpServers": {
    "markupr": {
      "command": "node",
      "args": ["/path/to/markupr/dist/mcp/index.mjs"]
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)