### PR TITLE
Add/enhance CLAUDE.md and custom commands

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,42 @@
+# Code Quality Audit
+
+Perform a targeted code quality audit of the markupr codebase.
+
+## Instructions
+
+1. **Run all static analysis:**
+   ```bash
+   npm run lint
+   npm run typecheck
+   ```
+   Report any errors or warnings.
+
+2. **Check for common issues in Electron apps:**
+   - IPC channels defined in `src/shared/types.ts` that are unused or missing handlers
+   - `nodeIntegration` or `contextIsolation` misconfigurations in window creation
+   - Missing error boundaries in React components
+   - Unhandled promise rejections in main process code
+   - Memory leaks from event listeners not being cleaned up
+
+3. **Review security considerations:**
+   - API keys should only be stored via keytar (never in plaintext config files)
+   - No `eval()`, `innerHTML`, or `dangerouslySetInnerHTML` with user-supplied data
+   - Preload script should not expose unnecessary APIs to the renderer
+   - Check `webPreferences` in BrowserWindow creation for safe defaults
+
+4. **Examine error handling patterns:**
+   - Verify try/catch around ffmpeg operations (FrameExtractor)
+   - Verify try/catch around Whisper operations (WhisperService)
+   - Verify try/catch around Claude API calls (ClaudeAnalyzer)
+   - Check that errors surface user-friendly messages, not raw stack traces
+
+5. **Check for stale code:**
+   - Unused imports or exports
+   - Dead code paths (unreachable conditions)
+   - TODO/FIXME/HACK comments that should be addressed
+
+6. **Provide a prioritized report:**
+   - **Critical** -- security or data loss risks
+   - **High** -- bugs or broken functionality
+   - **Medium** -- code quality and maintainability
+   - **Low** -- style and cleanup opportunities

--- a/.claude/commands/pick-task.md
+++ b/.claude/commands/pick-task.md
@@ -1,0 +1,23 @@
+You are an ORCHESTRATOR picking up a queued task from GitHub.
+
+1. Run: `gh issue list --repo eddiesanjuan/$REPO_NAME --label agent-task --label ready --state open --json number,title,body --limit 1`
+2. If no issues found, say "No tasks queued for this repo" and stop.
+3. Take the first issue. Comment on it: "🤖 Picked up by Claude Code on Eddie's laptop."
+4. Relabel: `gh issue edit <number> --add-label in-progress --remove-label ready`
+5. Read the issue body — it contains your full task instructions.
+6. Execute the task. Follow the instructions precisely.
+7. When done:
+   - Commit your work to a new branch (never main)
+   - Push the branch
+   - Create a PR with a clear description of what changed
+   - Comment on the issue with a link to the PR
+   - Relabel: `gh issue edit <number> --add-label completed --remove-label in-progress`
+8. If you fail or hit a blocker:
+   - Comment on the issue explaining what went wrong
+   - Relabel: `gh issue edit <number> --add-label failed --remove-label in-progress`
+
+CRITICAL RULES:
+- Never push to main
+- Always create a PR
+- If the task says "be cautious" or "preserve good state" — run tests before committing
+- One task at a time. Run this command again for the next one.

--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -1,0 +1,54 @@
+# Pre-Release Checklist
+
+Validate that markupr is ready for a new release. Run this before bumping the version.
+
+## Instructions
+
+1. **Verify the build succeeds:**
+   ```bash
+   npm run build
+   ```
+   This builds the desktop app, CLI, and MCP server. All three must succeed.
+
+2. **Run the full test suite:**
+   ```bash
+   npm test -- --run
+   ```
+   All tests must pass. Do not proceed if any fail.
+
+3. **Run lint and type checking:**
+   ```bash
+   npm run lint
+   npm run typecheck
+   ```
+   Zero errors required. Warnings are acceptable but should be noted.
+
+4. **Check version consistency:**
+   - Read `package.json` for the current version
+   - Read `CLAUDE.md` for the documented version
+   - Read `electron-builder.yml` for the builder config version
+   - Flag any mismatches
+
+5. **Review recent changes since last release:**
+   ```bash
+   git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD~20)..HEAD
+   ```
+   Categorize commits as: features, fixes, chores, breaking changes.
+
+6. **Check for uncommitted changes:**
+   ```bash
+   git status
+   ```
+   Working tree should be clean before release.
+
+7. **Verify native dependencies:**
+   ```bash
+   npm ls keytar sharp whisper-node
+   ```
+   Ensure native modules are installed and compatible.
+
+8. **Produce a release summary:**
+   - Suggested version bump (patch/minor/major) based on changes
+   - Draft CHANGELOG entry
+   - Any blockers or risks identified
+   - Confirmation: "Ready for release" or "Not ready -- [reasons]"

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,37 @@
+# Run Tests and Report Results
+
+Run the markupr test suite and report results with actionable analysis.
+
+## Instructions
+
+1. **Run the full test suite:**
+   ```bash
+   npm test -- --run
+   ```
+
+2. **If tests fail**, analyze each failure:
+   - Read the failing test file to understand what it expects
+   - Read the source file being tested to understand current behavior
+   - Determine if the failure is a regression (source changed) or a test that needs updating (requirements changed)
+   - Provide a clear summary: which tests failed, why, and a recommended fix
+
+3. **If all tests pass**, run coverage:
+   ```bash
+   npm run test:coverage -- --run
+   ```
+   Report coverage summary and identify any source files with 0% coverage that should have tests.
+
+4. **Check for untested modules:**
+   - Compare files in `src/main/` against test files in `tests/unit/`
+   - Flag any major module (SessionController, CrashRecovery, ErrorHandler, pipeline components, MCP tools) that lacks test coverage
+
+5. **Run type checking** as a bonus validation:
+   ```bash
+   npm run typecheck
+   ```
+
+6. **Provide a summary** with:
+   - Total tests: passed / failed / skipped
+   - Coverage highlights (if run)
+   - Any type errors found
+   - Recommended next steps (tests to write, failures to fix)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,26 @@
 
 ## Project Overview
 
-markupr is a macOS menu bar app that intelligently captures developer feedback. It records your screen and voice simultaneously, then uses an intelligent post-processing pipeline to correlate transcript timestamps with the screen recording — extracting the right frames at the right moments and stitching everything into a structured, AI-ready Markdown document. The output is purpose-built for AI coding agents: every screenshot placed exactly where it belongs, every issue clearly documented.
+markupr is a macOS/Windows menu bar app and CLI/MCP tool that intelligently captures developer feedback. It records your screen and voice simultaneously, then uses an intelligent post-processing pipeline to correlate transcript timestamps with the screen recording -- extracting the right frames at the right moments and stitching everything into a structured, AI-ready Markdown document. The output is purpose-built for AI coding agents: every screenshot placed exactly where it belongs, every issue clearly documented.
 
-**Version:** 2.3.0
+As of v2.4.0, markupr also ships as:
+- **CLI tool** (`npx markupr analyze ./recording.mov`) -- headless video analysis pipeline
+- **MCP server** (`npx markupr-mcp`) -- Model Context Protocol server for AI coding agents (capture screenshots, analyze video, start/stop recordings)
+
+**Version:** 2.4.0
 **License:** MIT (Open Source)
 
 ## Tech Stack
 
 - **Framework:** Electron + React + TypeScript
-- **Build:** electron-vite + Vite
+- **Build:** electron-vite + Vite (desktop), esbuild (CLI/MCP)
 - **Transcription:** Local Whisper (default), OpenAI Whisper-1 API (optional cloud)
 - **AI Analysis:** Anthropic Claude API (BYOK or premium tier)
-- **Testing:** Vitest
-- **Package:** electron-builder
+- **Testing:** Vitest (unit, integration, e2e)
+- **Package:** electron-builder (DMG, NSIS, AppImage)
 - **Styling:** Tailwind CSS
+- **Schema Validation:** Zod
+- **MCP:** @modelcontextprotocol/sdk
 
 ## Architecture
 
@@ -40,6 +46,7 @@ src/
 │   ├── analysis/           # Feedback analysis and categorization
 │   ├── audio/              # Microphone capture, VAD
 │   ├── capture/            # Screen capture via desktopCapturer
+│   ├── ipc/                # IPC handler registration and routing
 │   ├── output/             # Document generation and export
 │   │   ├── MarkdownGenerator.ts  # llms.txt-inspired markdown output
 │   │   ├── ExportService.ts      # Multi-format export (MD, PDF, HTML, JSON)
@@ -47,7 +54,7 @@ src/
 │   │   ├── FileManager.ts        # Session file management
 │   │   └── sessionAdapter.ts     # Type conversion utilities
 │   ├── pipeline/           # Post-processing pipeline
-│   │   ├── PostProcessor.ts      # Pipeline orchestrator (transcribe → analyze → extract → generate)
+│   │   ├── PostProcessor.ts      # Pipeline orchestrator (transcribe -> analyze -> extract -> generate)
 │   │   ├── TranscriptAnalyzer.ts # Heuristic key-moment detection
 │   │   └── FrameExtractor.ts     # ffmpeg-based video frame extraction
 │   ├── platform/           # Platform-specific code (Windows taskbar)
@@ -57,6 +64,24 @@ src/
 │   │   ├── WhisperService.ts     # Local Whisper integration
 │   │   └── ModelDownloadManager.ts # Whisper model download from HuggingFace
 │   └── windows/            # Window management (popover, taskbar)
+├── cli/                    # Headless CLI tool
+│   ├── index.ts            # CLI entry point (commander-based)
+│   └── CLIPipeline.ts      # Video analysis pipeline (ffmpeg + Whisper + markdown)
+├── mcp/                    # MCP server for AI coding agents
+│   ├── index.ts            # MCP entry point
+│   ├── server.ts           # MCP server setup
+│   ├── tools/              # MCP tool implementations
+│   │   ├── analyzeScreenshot.ts  # Analyze a screenshot with Claude
+│   │   ├── analyzeVideo.ts       # Analyze a video recording
+│   │   ├── captureScreenshot.ts  # Capture a screenshot
+│   │   ├── captureWithVoice.ts   # Capture with voice narration
+│   │   ├── startRecording.ts     # Start a recording session
+│   │   └── stopRecording.ts      # Stop a recording session
+│   ├── session/            # MCP session management
+│   ├── capture/            # MCP capture utilities
+│   ├── utils/              # MCP utilities
+│   ├── resources/          # MCP resource definitions
+│   └── types.ts            # MCP type definitions
 ├── renderer/               # React UI
 │   ├── App.tsx             # Main component with state machine UI
 │   ├── AppWrapper.tsx      # Root wrapper with providers
@@ -83,50 +108,109 @@ src/
 ## Commands
 
 ```bash
-npm run dev          # Development mode with hot reload
-npm run build        # Build for production
-npm run build:desktop # Build desktop app only
-npm test             # Run all tests
-npm run test:unit    # Run unit tests only
-npm run test:watch   # Run tests in watch mode
-npm run lint         # Lint code
-npm run lint:fix     # Auto-fix lint issues
-npm run typecheck    # TypeScript check
-npm run package      # Package for current platform
-npm run package:mac  # Package for macOS
-npm run package:win  # Package for Windows
+# Development
+npm run dev              # Development mode with hot reload
+npm run build            # Build everything (desktop + CLI + MCP)
+npm run build:desktop    # Build desktop app only
+npm run build:cli        # Build CLI tool only
+npm run build:mcp        # Build MCP server only
+
+# Testing
+npm test                 # Run all tests
+npm run test:unit        # Run unit tests only
+npm run test:integration # Run integration tests
+npm run test:e2e         # Run end-to-end tests
+npm run test:watch       # Run tests in watch mode
+npm run test:coverage    # Run tests with coverage report
+npm run test:ci          # Run tests for CI (with coverage)
+
+# Code Quality
+npm run lint             # Lint code
+npm run lint:fix         # Auto-fix lint issues
+npm run typecheck        # TypeScript type checking
+
+# Packaging
+npm run package          # Package for current platform
+npm run package:mac      # Package for macOS
+npm run package:win      # Package for Windows
+npm run dist:mac         # Build + package for macOS
+npm run release          # Build + publish release to GitHub
 ```
+
+## Testing
+
+Tests live in `tests/` and use Vitest with the `node` environment.
+
+```
+tests/
+├── setup.ts                    # Global test setup
+├── unit/                       # Unit tests
+│   ├── sessionController.test.ts
+│   ├── crashRecovery.test.ts
+│   ├── errorHandler.test.ts
+│   ├── tierManager.test.ts
+│   ├── exportService.test.ts
+│   ├── frameExtractor.test.ts
+│   ├── permissionManager.test.ts
+│   ├── cli.test.ts
+│   ├── mcp/                   # MCP server tests
+│   └── ...
+├── integration/               # Integration tests
+│   └── sessionFlow.test.ts
+├── e2e/                       # End-to-end tests
+│   └── criticalPaths.test.ts
+└── manual/                    # Manual test scripts
+```
+
+**Configuration:** `vitest.config.ts` at project root. Tests run in forked processes (`pool: 'forks'`) for isolation. Test timeout is 10 seconds.
+
+**Coverage thresholds:** lines 8%, functions 30%, branches 55%, statements 8%. Reports to `./coverage/`.
+
+**Writing tests:** Follow existing patterns -- mock Electron APIs and IPC channels. See `tests/setup.ts` for global mocks. Test files are co-located by module name (e.g., `sessionController.test.ts` tests `src/main/SessionController.ts`).
 
 ## Key Architecture Decisions
 
 ### State Machine
-The recording session is governed by a 7-state FSM: `idle → starting → recording → stopping → processing → complete → error`. Every state has a maximum duration enforced by a watchdog timer that forces recovery if anything gets stuck.
+The recording session is governed by a 7-state FSM: `idle -> starting -> recording -> stopping -> processing -> complete -> error`. Every state has a maximum duration enforced by a watchdog timer that forces recovery if anything gets stuck.
 
 ### Post-Processing Pipeline
-When recording stops, the pipeline runs: audio transcription (Whisper) → transcript analysis (key-moment detection) → video frame extraction (ffmpeg) → markdown generation. Each step degrades gracefully if a dependency is missing.
+When recording stops, the pipeline runs: audio transcription (Whisper) -> transcript analysis (key-moment detection) -> video frame extraction (ffmpeg) -> markdown generation. Each step degrades gracefully if a dependency is missing.
 
 ### Three-Tier Transcription
-1. **OpenAI Whisper-1 API** (optional, best quality) — cloud-based, requires API key
-2. **Local Whisper** (default) — runs on device, no API key needed
-3. **Timer-only** (fallback) — captures screenshots on a timer when no transcription is available
+1. **OpenAI Whisper-1 API** (optional, best quality) -- cloud-based, requires API key
+2. **Local Whisper** (default) -- runs on device, no API key needed
+3. **Timer-only** (fallback) -- captures screenshots on a timer when no transcription is available
 
 ### Crash Recovery
 Session state auto-saves to disk every 5 seconds. On restart after a crash, the app detects the incomplete session and offers recovery.
 
 ### Clipboard Bridge
-When a session completes, the **file path** to the markdown document is copied to clipboard — not the content. This is deliberate: the file persists on disk, and AI tools can read the full document including screenshots.
+When a session completes, the **file path** to the markdown document is copied to clipboard -- not the content. This is deliberate: the file persists on disk, and AI tools can read the full document including screenshots.
+
+### MCP Server
+The MCP server (`src/mcp/`) exposes markupr capabilities as tools for AI coding agents. Tools include screenshot capture, video analysis, and recording session control. Built on `@modelcontextprotocol/sdk`.
 
 ## IPC Communication
 
-All main/renderer communication goes through the preload script. See `src/shared/types.ts` for IPC channel names.
+All main/renderer communication goes through the preload script. See `src/shared/types.ts` for IPC channel names. IPC handlers are registered in `src/main/ipc/`.
+
+## CI/CD
+
+GitHub Actions workflows in `.github/workflows/`:
+- **ci.yml** -- Runs on every push/PR: lint, typecheck, tests
+- **release.yml** -- Triggered on version tags: builds and publishes desktop app to GitHub Releases
+- **deploy-landing.yml** -- Deploys the landing page (markupr.com)
+- **nightly.yml** -- Nightly builds for testing
+
+Releases are published to GitHub Releases via electron-builder. The app is code-signed and notarized for macOS (see `scripts/notarize.cjs`).
 
 ## Configuration
 
 No configuration required for first run. Local Whisper transcription works out of the box after downloading a model (~75MB for tiny, ~500MB for base).
 
 Optional API keys (stored securely in OS keychain):
-- **OpenAI** — for cloud post-session transcription
-- **Anthropic** — for AI-enhanced document analysis (BYOK mode)
+- **OpenAI** -- for cloud post-session transcription
+- **Anthropic** -- for AI-enhanced document analysis (BYOK mode)
 
 ## Development Notes
 
@@ -135,3 +219,6 @@ Optional API keys (stored securely in OS keychain):
 - Voice activity detection uses RMS amplitude analysis
 - All settings validated against JSON schema
 - Secure API key storage via keytar (macOS Keychain, Windows Credential Manager) with encrypted fallback
+- Native module rebuilds handled by `electron-rebuild` (keytar, sharp)
+- CLI and MCP builds use esbuild (see `scripts/build-cli.mjs` and `scripts/build-mcp.mjs`)
+- Published to npm as `markupr` (CLI) and `markupr-mcp` (MCP server)


### PR DESCRIPTION
## Summary

- **Enhanced CLAUDE.md** to reflect the current state of markupr v2.4.0, including CLI tool, MCP server, and expanded project documentation
- **Added 3 new slash commands** (`/test`, `/audit`, `/release-check`) alongside the 2 existing ones (`/pick-task`, `/review-feedback`)

## CLAUDE.md Changes

- Updated version from 2.3.0 to 2.4.0
- Added CLI and MCP server to project overview
- Expanded tech stack (esbuild, Zod, MCP SDK)
- Added `cli/` and `mcp/` directories to architecture tree with full file listings
- Added `ipc/` directory to main process tree
- Added complete Testing section (test structure, config, coverage thresholds, writing patterns)
- Added CI/CD section (4 GitHub Actions workflows)
- Added MCP Server architecture decision
- Expanded Commands section with all npm scripts organized by category
- Added development notes for native modules, esbuild builds, and npm publishing

## New Slash Commands

| Command | Purpose |
|---------|---------|
| `/test` | Run test suite, analyze failures, report coverage, check for untested modules |
| `/audit` | Code quality audit -- lint, security, error handling, Electron best practices |
| `/release-check` | Pre-release validation -- build, tests, version consistency, changelog draft |

## Existing Commands (unchanged)

| Command | Purpose |
|---------|---------|
| `/pick-task` | Pick up a queued GitHub issue labeled `agent-task` |
| `/review-feedback` | Review a markupr feedback session and create an action plan |

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify all 5 slash commands are discoverable via `/` in Claude Code
- [ ] Run `/test` command and confirm it executes the test workflow
- [ ] Run `/audit` command and confirm it performs the code audit
- [ ] Run `/release-check` command and confirm it runs the pre-release checklist

Generated with [Claude Code](https://claude.com/claude-code)