### PR TITLE
fix: resolve 5 audit findings for v2.4.1 hardening

### DIFF
--- a/src/main/audio/AudioCapture.ts
+++ b/src/main/audio/AudioCapture.ts
@@ -323,7 +323,7 @@ class AudioCaptureServiceImpl extends EventEmitter implements AudioCaptureServic
       const successHandler = () => {
         clearTimeout(timeout);
         ipcMain.removeListener(AUDIO_IPC_CHANNELS.CAPTURE_STARTED, successHandler);
-        ipcMain.removeListener(AUDIO_IPC_CHANNELS.CAPTURE_ERROR, errorHandler);
+        ipcMain.removeListener(AUDIO_IPC_CHANNELS.CAPTURE_ERROR, captureErrorHandler);
 
         this.capturing = true;
         this.stopRequested = false;
@@ -347,15 +347,15 @@ class AudioCaptureServiceImpl extends EventEmitter implements AudioCaptureServic
         resolve();
       };
 
-      const errorHandler = (_event: Electron.IpcMainEvent, error: string) => {
+      const captureErrorHandler = (_event: Electron.IpcMainEvent, error: string) => {
         clearTimeout(timeout);
         ipcMain.removeListener(AUDIO_IPC_CHANNELS.CAPTURE_STARTED, successHandler);
-        ipcMain.removeListener(AUDIO_IPC_CHANNELS.CAPTURE_ERROR, errorHandler);
+        ipcMain.removeListener(AUDIO_IPC_CHANNELS.CAPTURE_ERROR, captureErrorHandler);
         reject(new Error(error));
       };
 
       ipcMain.once(AUDIO_IPC_CHANNELS.CAPTURE_STARTED, successHandler);
-      ipcMain.once(AUDIO_IPC_CHANNELS.CAPTURE_ERROR, errorHandler);
+      ipcMain.once(AUDIO_IPC_CHANNELS.CAPTURE_ERROR, captureErrorHandler);
 
       // Send start command to renderer with config
       this.mainWindow!.webContents.send(AUDIO_IPC_CHANNELS.START_CAPTURE, {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -16,6 +16,21 @@ const VERSION =
 
 log(`markupr MCP server v${VERSION} starting...`);
 
-const server = createServer();
-const transport = new StdioServerTransport();
-await server.connect(transport);
+process.on('uncaughtException', (error) => {
+  log(`Uncaught exception: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason) => {
+  log(`Unhandled rejection: ${reason instanceof Error ? reason.message : String(reason)}`);
+  process.exit(1);
+});
+
+try {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+} catch (error) {
+  log(`Failed to start MCP server: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/src/renderer/contexts/RecordingContext.tsx
+++ b/src/renderer/contexts/RecordingContext.tsx
@@ -6,7 +6,7 @@
  * This is the foundational context that other contexts depend on.
  */
 
-import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { SessionPayload, SessionState, ReviewSession } from '../../shared/types';
 import { getScreenRecordingRenderer } from '../capture/ScreenRecordingRenderer';
 import { useCrashRecovery } from '../components';
@@ -633,7 +633,7 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   // ---------------------------------------------------------------------------
   // Context value
   // ---------------------------------------------------------------------------
-  const value: RecordingContextValue = {
+  const value: RecordingContextValue = useMemo(() => ({
     state,
     duration,
     screenshotCount,
@@ -671,7 +671,47 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     discardSession,
     reviewSave,
     reviewClose,
-  };
+  }), [
+    state,
+    duration,
+    screenshotCount,
+    isPaused,
+    isMutating,
+    audioLevel,
+    isVoiceActive,
+    lastCapture,
+    reportPath,
+    recordingPath,
+    audioPath,
+    sessionDir,
+    reviewSession,
+    errorMessage,
+    hasTranscriptionCapability,
+    recentSessions,
+    loadRecentSessions,
+    rawProcessingProgress,
+    // processingStartedAtRef.current is intentionally excluded from deps:
+    // it only changes when state changes (which is in deps), and ref.current
+    // is not a valid React dependency (mutations don't trigger re-renders).
+    showReviewEditor,
+    setShowReviewEditor,
+    incompleteSession,
+    isCheckingRecovery,
+    startSession,
+    stopSession,
+    togglePause,
+    manualCapture,
+    copyReportPath,
+    openReportFolder,
+    copyRecordingPath,
+    copyAudioPath,
+    openRecent,
+    copyRecentPath,
+    recoverSession,
+    discardSession,
+    reviewSave,
+    reviewClose,
+  ]);
 
   return (
     <RecordingContext.Provider value={value}>


### PR DESCRIPTION
## Summary

Comprehensive 3-auditor parallel audit identified 50 issues across the Markupr codebase. The top 5 most impactful fixes were selected based on user-facing impact, bug severity, code quality improvement, and implementation effort, then implemented by 3 parallel developer agents.

### Changes

- **AudioCapture variable shadowing fix** (`src/main/audio/AudioCapture.ts`): Renamed local `errorHandler` to `captureErrorHandler` to eliminate shadowing of the imported `ErrorHandler` singleton. This was a critical maintenance trap where the local IPC callback and the centralized error handler shared the same name.

- **MCP server error handling** (`src/mcp/index.ts`): Added try/catch around server startup and process-level `uncaughtException`/`unhandledRejection` handlers. Previously, any startup failure would crash the MCP server silently with no diagnostic output.

- **RecordingContext performance** (`src/renderer/contexts/RecordingContext.tsx`): Wrapped the context value object in `useMemo` with proper dependency array. Previously, the value was recreated every render, causing cascading re-renders across the entire UI tree on every audio level tick (~4Hz) and duration update (1Hz).

- **SessionController.destroy() state coverage** (`src/main/SessionController.ts`): Expanded the state guard to cover `stopping` and `processing` states in addition to `recording` and `starting`. This prevents session data loss when the app quits while post-processing is active.

- **SessionController FSM race condition guards** (`src/main/SessionController.ts`): Added `recoveryInProgress` guard to `watchdogCheck()` to prevent re-entrance during force recovery. Also added `.catch()` to the unhandled `stop()` promise in `checkRecordingDuration()` to prevent unhandled promise rejections at max recording duration.

## Test plan

- [x] Full test suite: 644/644 tests passing
- [x] Lint: 0 errors, 5 warnings (all pre-existing, zero new)
- [x] TypeCheck: All errors pre-existing (MCP module resolution), zero new
- [x] All changes are focused and minimal — no cosmetic refactoring
- [x] Existing patterns preserved (error handling style, naming conventions)
- [ ] Manual: Start/stop recording session to verify FSM changes
- [ ] Manual: Quit app during processing to verify session is saved
- [ ] Manual: Verify MCP server logs errors on startup failure

## Audit Coverage

| Auditor | Findings | Breakdown |
|---------|----------|-----------|
| Bug & Error Handling | 14 | 2 critical, 3 high, 5 medium, 4 low |
| Performance & Architecture | 14 | 1 critical, 4 high, 6 medium, 3 low |
| Code Quality & UX | 22 | 2 critical, 6 high, 9 medium, 5 low |
| **Total** | **50** | Full reports in `.claude/runs/20260214-markupr-audit/` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)