### PR TITLE
Add advanced slash commands

### DIFF
--- a/.claude/commands/perf.md
+++ b/.claude/commands/perf.md
@@ -1,0 +1,139 @@
+# Perf -- Performance Optimization Audit
+
+Analyze markupr's performance characteristics across its three runtimes: Electron desktop app, CLI tool, and MCP server. Identify bottlenecks, heavy dependencies, and anti-patterns with prioritized recommendations.
+
+## Instructions
+
+### 1. Bundle Size Analysis
+
+Build all targets and measure output sizes:
+
+```bash
+cd ~/Projects/markupr && npm run build 2>&1
+
+# Measure each build output
+du -sh dist/main/
+du -sh dist/renderer/
+du -sh dist/cli/
+du -sh dist/mcp/
+du -sh dist/preload/
+
+# Find the largest individual files
+find dist/ -type f -name "*.mjs" -o -name "*.js" -o -name "*.css" | xargs ls -lhS | head -20
+```
+
+Report the size of each build target. For the renderer bundle specifically, check if source maps are included in production (they should not be).
+
+### 2. Dependency Weight Analysis
+
+Assess the heaviest dependencies and whether lighter alternatives exist:
+
+| Dependency | Purpose | Risk Area |
+|---|---|---|
+| `sharp` | Image optimization for AI pipeline (`src/main/ai/ImageOptimizer.ts`) | Native module, large binary (~30MB). Check if it's tree-shaken or fully bundled. For CLI/MCP, could canvas or jimp be lighter? |
+| `@anthropic-ai/sdk` | Claude API calls (`src/main/ai/ClaudeAnalyzer.ts`) | Large SDK. Check if markupr uses enough of it to justify full import vs. raw fetch |
+| `electron-store` | Settings persistence (`src/main/settings/`) | Pulls in conf, atomically, etc. Check if electron's built-in safeStorage + JSON would suffice |
+| `whisper-node` | Local transcription (`src/main/transcription/WhisperService.ts`) | Native module with binary download. Check startup impact |
+| `keytar` | Secure API key storage (`src/main/settings/`) | Native module. Check if Electron safeStorage could replace it |
+| `zod` | Schema validation (`src/shared/`) | Check v4 bundle size. v4 is significantly larger than v3 |
+
+For each dependency:
+- Read the actual import sites to see how much of the package is used
+- Check if it's properly externalized in `electron.vite.config.ts` (main process deps should be external)
+- Check if CLI/MCP builds in `scripts/build-cli.mjs` and `scripts/build-mcp.mjs` properly externalize or bundle
+
+### 3. Electron-Specific Performance Anti-Patterns
+
+Check for these common Electron performance issues:
+
+**Startup Time**
+- Read `src/main/index.ts`: Are heavy modules imported at top level or lazy-loaded?
+- Whisper model loading, ffmpeg checks, and AI pipeline initialization should be deferred until first use
+- Check if `ModelDownloadManager` runs checks at startup
+
+**Memory Leaks in Main Process**
+- Read `src/main/SessionController.ts`: Are event listeners registered in constructor and cleaned up in destroy/dispose?
+- Read `src/main/audio/` and `src/main/capture/`: Are MediaRecorder/stream resources released on session end?
+- Check `src/main/CrashRecovery.ts`: Is the 5-second auto-save interval cleared when a session completes?
+- Search for `setInterval` and `setTimeout` without corresponding `clearInterval`/`clearTimeout`
+
+**IPC Overhead**
+- Read `src/main/ipc/`: Are large payloads (screenshots, audio chunks) being sent through IPC?
+- Audio level updates (`IPC_CHANNELS.AUDIO_LEVEL`) fire frequently -- check if they're throttled
+- Screenshot data should use file paths through IPC, not raw buffer data
+
+**Renderer Performance**
+- Read `src/renderer/App.tsx`: Check for unnecessary re-renders from IPC event subscriptions
+- Read `src/renderer/components/AudioWaveform.tsx`: Animation frame updates should use `requestAnimationFrame`, not `setInterval`
+- Read `src/renderer/components/AnnotationOverlay.tsx`: Canvas drawing operations -- check for per-frame allocations
+- Check if `React.memo` is used on components that receive stable props (SessionHistory list items, etc.)
+
+### 4. Post-Processing Pipeline Performance
+
+The pipeline (`src/main/pipeline/`) is the most compute-intensive path. Analyze:
+
+**FrameExtractor (`src/main/pipeline/FrameExtractor.ts`)**
+- How many ffmpeg processes are spawned? Should be one with multiple output timestamps, not one per frame
+- What resolution are extracted frames? Full resolution is wasteful if they'll be optimized for Claude API
+- Are frames extracted sequentially or in parallel?
+
+**TranscriptAnalyzer (`src/main/pipeline/TranscriptAnalyzer.ts`)**
+- Is key-moment detection O(n) or worse?
+- Are there redundant passes over the transcript?
+
+**ImageOptimizer (`src/main/ai/ImageOptimizer.ts`)**
+- Sharp operations should be chained (resize + format + quality in one pipeline), not sequential
+- Check if images are processed in parallel with `Promise.all` vs. sequentially
+- What target dimensions and quality? Claude's vision API has diminishing returns above 1568px
+
+**PostProcessor (`src/main/pipeline/PostProcessor.ts`)**
+- Are pipeline stages overlapped where possible (e.g., start frame extraction while transcription is still running)?
+- Is there a timeout if any stage hangs?
+
+### 5. CLI and MCP Startup Performance
+
+```bash
+# Measure CLI cold start time
+cd ~/Projects/markupr && time node dist/cli/index.mjs --help 2>&1
+
+# Measure MCP cold start overhead (if possible)
+cd ~/Projects/markupr && time node -e "require('./dist/mcp/index.mjs')" 2>&1
+```
+
+For CLI, check:
+- Does `src/cli/index.ts` import the entire Electron main process code, or only what it needs?
+- Are heavy imports (sharp, whisper-node) loaded eagerly or only when the `analyze` command runs?
+- Commander.js setup should be near-instant
+
+For MCP, check:
+- Does the MCP server import sharp/whisper-node at startup or per-tool-call?
+- Idle memory footprint matters since MCP servers run persistently
+
+### 6. Prioritized Recommendations
+
+Produce a ranked list:
+
+```
+=== PERFORMANCE AUDIT: markupr ===
+
+CRITICAL (user-visible latency or resource waste):
+1. [issue] -- [location] -- [estimated impact] -- [fix]
+
+HIGH (measurable improvement opportunity):
+1. [issue] -- [location] -- [estimated impact] -- [fix]
+
+MEDIUM (code hygiene, prevents future problems):
+1. [issue] -- [location] -- [estimated impact] -- [fix]
+
+LOW (micro-optimizations, nice to have):
+1. [issue] -- [location] -- [estimated impact] -- [fix]
+
+BUNDLE SIZE SUMMARY:
+- Desktop main: XXkb (target: <500kb)
+- Desktop renderer: XXkb (target: <1MB)
+- CLI: XXkb (target: <200kb)
+- MCP: XXkb (target: <200kb)
+
+HEAVIEST DEPENDENCIES:
+1. [package] -- [size] -- [used for] -- [lighter alternative?]
+```

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,0 +1,128 @@
+# Refactor -- Safe Refactoring with Test Guard Rails
+
+Perform incremental, test-guarded refactoring of a specified area of the markupr codebase. Every change is validated by re-running the test suite to ensure nothing breaks.
+
+**Target area:** $ARGUMENTS
+
+If no argument is provided, ask the user what area to refactor. Examples:
+- A specific file: `src/main/SessionController.ts`
+- A module: `src/main/pipeline/`
+- A pattern: `error handling`, `IPC layer`, `AI pipeline`
+
+## Instructions
+
+### 1. Establish Baseline -- Run Tests First
+
+```bash
+cd ~/Projects/markupr && npm test -- --run 2>&1
+```
+
+Record the baseline: total tests, passed, failed. If any tests are ALREADY failing, report them and ask the user whether to proceed (refactoring on a red test suite is risky).
+
+### 2. Read and Analyze the Target Code
+
+Read the target file(s) thoroughly. Identify refactoring opportunities specific to markupr's Electron + React + TypeScript stack:
+
+**Electron Main Process (`src/main/`)**
+- SessionController FSM: overly complex state transitions, duplicated guard clauses
+- IPC handlers in `src/main/ipc/`: handlers doing too much work (should delegate to services)
+- CrashRecovery: deeply nested try/catch, unclear recovery paths
+- Pipeline steps: tight coupling between PostProcessor, TranscriptAnalyzer, FrameExtractor
+- Settings: redundant validation that Zod should handle
+
+**React Renderer (`src/renderer/`)**
+- Components over 200 lines that should be split (especially `App.tsx`, `SettingsPanel.tsx`, `SessionReview.tsx`)
+- Props drilling that should use React context or composition
+- `useEffect` cleanup functions missing for event subscriptions via `window.markupr.*`
+- Inline styles or magic numbers that should be Tailwind utilities or constants
+- State that lives in components but should be lifted or extracted to hooks
+
+**Shared / Cross-cutting**
+- Type definitions in `src/shared/types.ts` that have grown too large (split by domain)
+- Duplicated type definitions between main and renderer
+- String-based IPC channel names that could benefit from a type-safe wrapper
+- Error handling patterns that swallow errors silently
+
+**CLI and MCP (`src/cli/`, `src/mcp/`)**
+- Code duplicated between CLI pipeline and main process pipeline
+- MCP tools with similar boilerplate that could share a base pattern
+
+### 3. Propose Changes Before Making Them
+
+For each refactoring opportunity found, describe:
+- **What**: The specific change (extract function, rename, split file, simplify conditional)
+- **Why**: The code smell or principle violated (SRP, DRY, readability, testability)
+- **Risk**: Low (rename/extract), Medium (restructure), High (behavior change)
+- **Files affected**: List every file that will be modified
+
+Present the plan and wait for confirmation before proceeding, unless the user said to go ahead.
+
+### 4. Make Changes Incrementally
+
+Apply ONE refactoring at a time, then immediately verify:
+
+```bash
+cd ~/Projects/markupr && npm test -- --run 2>&1
+```
+
+If tests fail after a change:
+1. Report which test(s) broke and why
+2. Revert the change or fix the test (only if the test was testing implementation details, not behavior)
+3. Re-run tests to confirm green
+
+Do NOT batch multiple refactoring changes before running tests.
+
+### 5. Type Check After Each Change
+
+```bash
+cd ~/Projects/markupr && npm run typecheck 2>&1
+```
+
+TypeScript errors are blockers. Fix them before proceeding to the next refactoring step. This is especially important for:
+- IPC channel type changes (affects `src/shared/types.ts`, `src/preload/index.ts`, and all handlers)
+- Renamed exports (affects all importers)
+- Changed function signatures (affects callers across main/renderer boundary)
+
+### 6. Lint After Each Change
+
+```bash
+cd ~/Projects/markupr && npm run lint 2>&1
+```
+
+Fix any new lint errors introduced by the refactoring. Use `npm run lint:fix` for auto-fixable issues.
+
+### 7. Final Validation
+
+After all refactoring steps are complete, run the full validation:
+
+```bash
+cd ~/Projects/markupr && npm test -- --run 2>&1
+cd ~/Projects/markupr && npm run typecheck 2>&1
+cd ~/Projects/markupr && npm run lint 2>&1
+cd ~/Projects/markupr && npm run build 2>&1
+```
+
+All four must pass.
+
+### 8. Report
+
+Produce a summary:
+
+```
+=== REFACTORING REPORT ===
+
+Target: [what was refactored]
+Baseline: X tests passing before refactoring
+Final: X tests passing after refactoring
+
+Changes Made:
+1. [change] -- [rationale] -- [files]
+2. ...
+
+Tests: PASS / FAIL
+Typecheck: PASS / FAIL
+Lint: PASS / FAIL
+Build: PASS / FAIL
+
+Net effect: [simpler code, better separation, improved testability, etc.]
+```

--- a/.claude/commands/security.md
+++ b/.claude/commands/security.md
@@ -1,0 +1,183 @@
+# Security -- Electron Application Security Audit
+
+Perform a thorough security audit of markupr, an Electron app that handles API keys, screen recordings, voice data, and AI API communication. This audit covers Electron-specific attack surfaces, OWASP Top 10 adapted for desktop apps, and markupr's specific threat model.
+
+## Threat Model
+
+markupr's attack surface includes:
+- **API keys** (OpenAI, Anthropic) stored via keytar/OS keychain
+- **Screen recordings** and **voice recordings** saved to disk
+- **Network traffic** to OpenAI Whisper API, Anthropic Claude API, HuggingFace model downloads
+- **Local Whisper binary** downloaded from HuggingFace and executed
+- **IPC bridge** between Electron main and renderer processes
+- **MCP server** accepting tool calls from external AI agents
+- **CLI tool** processing arbitrary video files from disk
+- **Auto-updater** downloading and installing updates from GitHub Releases
+
+## Instructions
+
+### 1. Dependency Vulnerability Scan
+
+```bash
+cd ~/Projects/markupr && npm audit --omit=dev 2>&1
+cd ~/Projects/markupr && npm audit 2>&1
+```
+
+Report all vulnerabilities by severity (critical, high, moderate, low). For each critical/high:
+- Which package and what CVE?
+- Is it in a production dependency or dev-only?
+- Is it actually reachable in markupr's code paths?
+
+### 2. Hardcoded Secrets Scan
+
+Search the entire codebase for leaked secrets:
+
+```bash
+cd ~/Projects/markupr && grep -rn "sk-\|api[_-]key\|secret\|token\|password\|credential" src/ --include="*.ts" --include="*.tsx" -i 2>&1
+cd ~/Projects/markupr && grep -rn "ANTHROPIC_API_KEY\|OPENAI_API_KEY\|GITHUB_TOKEN" src/ .env* .github/ --include="*.ts" --include="*.tsx" --include="*.yml" --include="*.env*" 2>&1
+```
+
+Verify:
+- API keys are ONLY accessed via keytar (`src/main/settings/SettingsManager.ts`)
+- No API keys in environment variables, config files, or committed `.env` files
+- No keys in test fixtures or mock data
+- The preload script (`src/preload/index.ts`) does not expose raw API keys to the renderer
+- Check `electron-builder.yml` and `scripts/notarize.cjs` for hardcoded signing credentials
+
+### 3. Electron Security Configuration
+
+Read the BrowserWindow creation code in `src/main/index.ts` and verify:
+
+**webPreferences (Critical)**
+- `nodeIntegration` MUST be `false` (or absent, as false is default)
+- `contextIsolation` MUST be `true`
+- `sandbox` should be `true` if possible
+- `webSecurity` MUST NOT be set to `false`
+- `allowRunningInsecureContent` MUST NOT be set to `true`
+- `experimentalFeatures` should be `false`
+- `enableRemoteModule` MUST be `false` (or absent)
+
+**Content Security Policy**
+- Check if a CSP is set via `session.defaultSession.webRequest.onHeadersReceived` or in the HTML
+- Renderer should not be able to load arbitrary external resources
+- `unsafe-inline` and `unsafe-eval` in script-src are red flags
+
+**Navigation and Window Opening**
+- Check for `will-navigate` handler that blocks external navigation
+- Check for `setWindowOpenHandler` that prevents arbitrary window creation
+- The app should not navigate to external URLs in the main window
+
+### 4. Preload Script API Surface Audit
+
+Read `src/preload/index.ts` thoroughly. The preload script is the security boundary between main and renderer. Verify:
+
+- No direct `ipcRenderer.send()` or `ipcRenderer.invoke()` with user-controlled channel names
+- All exposed APIs use hardcoded `IPC_CHANNELS.*` constants
+- No generic `ipcRenderer.on(channel)` where `channel` comes from renderer input
+- The `copyToClipboard` function does not pass unsanitized data
+- The `settings.import()` function validates imported JSON before applying
+- File paths received from renderer (e.g., `output.openFolder(sessionDir)`) are validated/sanitized in the main process handler
+
+### 5. IPC Handler Input Validation
+
+Read the IPC handlers in `src/main/ipc/`. For each handler, check:
+
+- Are arguments validated before use? (Zod schemas preferred)
+- Can a malicious renderer forge IPC messages to:
+  - Read arbitrary files (via `output.openFolder` with path traversal)?
+  - Execute arbitrary commands (via ffmpeg or Whisper with crafted input)?
+  - Access API keys directly?
+  - Write to arbitrary locations?
+
+Specific handlers to scrutinize:
+- `SESSION_START` -- does `sourceId` get validated?
+- `SCREEN_RECORDING_START` -- does `sessionId` get sanitized before building file paths?
+- `SCREEN_RECORDING_CHUNK` -- is the chunk size bounded?
+- `SETTINGS_IMPORT` -- is imported JSON schema-validated?
+- `OUTPUT_OPEN_FOLDER` -- is the path restricted to the output directory?
+- `WHISPER_DOWNLOAD_MODEL` -- is the model name validated against an allowlist?
+
+### 6. Command Injection via External Processes
+
+markupr spawns child processes. Check each for injection risks:
+
+**ffmpeg (`src/main/pipeline/FrameExtractor.ts`)**
+- Are file paths passed to ffmpeg properly escaped/quoted?
+- Can a crafted filename or path inject ffmpeg flags or shell commands?
+- Is ffmpeg invoked via `child_process.spawn` (safer) or `exec` (shell injection risk)?
+
+**Whisper (`src/main/transcription/WhisperService.ts`)**
+- Same questions as ffmpeg
+- Is the Whisper binary path validated before execution?
+- Could a replaced Whisper binary execute arbitrary code?
+
+**notarize script (`scripts/notarize.cjs`)**
+- Does it use environment variables safely?
+- No shell injection via Apple ID or team ID?
+
+### 7. Network Security
+
+**API Communication**
+- Read `src/main/ai/ClaudeAnalyzer.ts`: Are all API calls over HTTPS?
+- Read Whisper cloud transcription code: Is the OpenAI API endpoint hardcoded to `https://`?
+- Are API keys sent in headers (Authorization), not query parameters?
+
+**Model Downloads**
+- Read `src/main/transcription/ModelDownloadManager.ts`: Is the HuggingFace download URL hardcoded or user-configurable?
+- Is the downloaded model checksum-verified?
+- Could a MITM attack replace the Whisper model with a malicious binary?
+
+**Auto-Updater**
+- Read `src/main/AutoUpdater.ts`: Is update verification enabled?
+- Does `electron-updater` verify code signatures on downloaded updates?
+- Is the update feed URL locked to `github.com/eddiesanjuan/markupr`?
+
+### 8. Data at Rest Security
+
+- Where are session recordings stored? Check `src/main/output/FileManager.ts`
+- Are recordings accessible to other applications?
+- Is there a session cleanup/deletion mechanism that properly removes files?
+- Do crash recovery files (`CrashRecovery.ts`) persist sensitive data (transcripts with potentially confidential info)?
+- Is `electron-store` data encrypted or plaintext on disk?
+
+### 9. MCP Server Security
+
+Read `src/mcp/server.ts` and each tool in `src/mcp/tools/`:
+
+- Can an MCP client trigger screen capture without user consent?
+- Can an MCP client access files outside the session directory?
+- Are tool inputs validated with Zod schemas?
+- Is there rate limiting on tool calls?
+- Can an MCP client exfiltrate data by crafting tool call arguments?
+- Does `startRecording`/`stopRecording` require any authentication?
+
+### 10. OWASP Desktop Top 10 Checklist
+
+Produce a checklist adapted for markupr:
+
+```
+=== SECURITY AUDIT: markupr vX.X.X ===
+
+[PASS/FAIL/PARTIAL] D1: Injection (command injection via ffmpeg/Whisper, path traversal via IPC)
+[PASS/FAIL/PARTIAL] D2: Broken Authentication (API key storage, MCP server access control)
+[PASS/FAIL/PARTIAL] D3: Sensitive Data Exposure (recordings on disk, crash recovery data, API keys in memory)
+[PASS/FAIL/PARTIAL] D4: Insecure Deserialization (IPC message handling, settings import, MCP tool inputs)
+[PASS/FAIL/PARTIAL] D5: Broken Access Control (renderer->main boundary, file system access, MCP tool permissions)
+[PASS/FAIL/PARTIAL] D6: Security Misconfiguration (Electron webPreferences, CSP, auto-updater)
+[PASS/FAIL/PARTIAL] D7: Insufficient Logging (crash logs, audit trail for sensitive operations)
+[PASS/FAIL/PARTIAL] D8: Insecure Communication (API calls over HTTPS, model downloads, update feed)
+[PASS/FAIL/PARTIAL] D9: Using Components with Known Vulnerabilities (npm audit results)
+[PASS/FAIL/PARTIAL] D10: Insufficient Binary Protections (code signing, notarization, hardened runtime)
+
+CRITICAL FINDINGS:
+- [finding with file path and line number]
+
+HIGH FINDINGS:
+- [finding]
+
+MEDIUM FINDINGS:
+- [finding]
+
+RECOMMENDATIONS (prioritized):
+1. [action] -- [effort: low/medium/high] -- [impact: low/medium/high]
+```

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,131 @@
+# Ship -- Full Release Prep
+
+Run a comprehensive release readiness assessment for markupr. This goes beyond `release-check` by generating changelogs, scanning for tech debt markers, checking dependency health, and producing a final go/no-go verdict.
+
+## Instructions
+
+### 1. Run the Full Test Suite with Coverage
+
+```bash
+cd ~/Projects/markupr && npm run test:ci -- --run
+```
+
+Report: total tests, passed, failed, skipped, and coverage percentages for lines/functions/branches/statements. Compare against the thresholds in `vitest.config.ts` (lines 8%, functions 30%, branches 55%, statements 8%). Flag if any threshold is missed.
+
+### 2. Lint and Type Check
+
+```bash
+cd ~/Projects/markupr && npm run lint 2>&1; npm run typecheck 2>&1
+```
+
+Report error count and warning count separately. Zero errors required for ship. Warnings are acceptable but list them.
+
+### 3. Version Consistency Check
+
+Read and compare the version string across all of these sources:
+- `package.json` `"version"` field
+- `CLAUDE.md` `**Version:**` line
+- `electron-builder.yml` (check if `artifactName` patterns reference a hardcoded version)
+- Any version constant in `src/main/index.ts` or `src/shared/` if present
+
+Flag any mismatch. All must agree before shipping.
+
+### 4. Build Validation
+
+Run all three build targets and confirm each succeeds:
+
+```bash
+cd ~/Projects/markupr && npm run build 2>&1
+```
+
+This runs `node scripts/build.mjs` which builds desktop (electron-vite), CLI (esbuild), and MCP (esbuild). All three must succeed. Report output sizes for:
+- `dist/main/index.mjs`
+- `dist/cli/index.mjs`
+- `dist/mcp/index.mjs`
+- `dist/renderer/` total size
+
+### 5. Git Status and Unpushed Commits
+
+```bash
+cd ~/Projects/markupr && git status --short 2>&1
+cd ~/Projects/markupr && git log origin/main..HEAD --oneline 2>&1
+```
+
+Flag: uncommitted changes, untracked files, unpushed commits. The working tree should be clean and fully pushed before a release.
+
+### 6. Changelog Generation
+
+```bash
+cd ~/Projects/markupr && git log $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD~30)..HEAD --oneline --no-merges
+```
+
+Categorize each commit into:
+- **Features** (feat:, add:, new:)
+- **Fixes** (fix:, bugfix:, patch:)
+- **Refactoring** (refactor:, cleanup:, chore:)
+- **Documentation** (docs:, readme:)
+- **Breaking Changes** (breaking:, BREAKING CHANGE in body)
+
+Format as a draft CHANGELOG entry with the current version from `package.json`. Include commit hashes for traceability.
+
+### 7. TODO/FIXME/HACK Scan
+
+Search the `src/` directory for tech debt markers:
+
+```bash
+cd ~/Projects/markupr && grep -rn "TODO\|FIXME\|HACK\|XXX\|TEMP\|WORKAROUND" src/ --include="*.ts" --include="*.tsx" 2>&1
+```
+
+Report each one with file path and line number. Categorize by severity:
+- **FIXME/HACK** -- should ideally be resolved before shipping
+- **TODO** -- acceptable to ship with, but document in release notes
+- **TEMP/WORKAROUND** -- flag for review, may indicate fragile code
+
+### 8. Dependency Freshness
+
+```bash
+cd ~/Projects/markupr && npm outdated 2>&1
+```
+
+For each outdated package, note:
+- Current vs latest version
+- Whether it's a major version behind (risky to upgrade)
+- Whether it's a security-sensitive dependency (electron, keytar, sharp, @anthropic-ai/sdk, @modelcontextprotocol/sdk, whisper-node)
+
+Do NOT block the release for outdated deps, but flag any that are more than one major version behind.
+
+### 9. Native Module Compatibility
+
+```bash
+cd ~/Projects/markupr && npm ls keytar sharp whisper-node 2>&1
+```
+
+Verify native modules resolve correctly. These are the modules that need electron-rebuild and are the most common source of packaging failures.
+
+### 10. Go / No-Go Summary
+
+Produce a structured verdict:
+
+```
+=== SHIP READINESS: markupr vX.X.X ===
+
+BLOCKERS (must fix before release):
+- [ ] ... or "None"
+
+WARNINGS (acceptable but should be tracked):
+- [ ] ...
+
+RELEASE TYPE RECOMMENDATION:
+- patch / minor / major (based on changelog analysis)
+
+VERDICT: GO / NO-GO
+```
+
+A release is NO-GO if ANY of these are true:
+- Tests fail
+- Lint errors exist
+- Build fails for any target (desktop, CLI, MCP)
+- Version mismatch across package.json / CLAUDE.md
+- Uncommitted changes in the working tree
+
+A release is GO if all the above pass, even with warnings.


### PR DESCRIPTION
## Summary

Adds 4 advanced slash commands deeply tailored to markupr's Electron + React + TypeScript architecture:

- **`/ship`** -- Full release prep with test suite, lint, typecheck, version consistency across package.json/CLAUDE.md/electron-builder.yml, build validation for all 3 targets (desktop/CLI/MCP), changelog generation from git history, TODO/FIXME scan, dependency freshness check, and a structured go/no-go verdict with blockers listed
- **`/refactor`** -- Safe incremental refactoring that runs tests before and after every change. Includes markupr-specific refactoring patterns for SessionController FSM, IPC handlers, pipeline coupling, React components over 200 lines, missing useEffect cleanup for `window.markupr.*` subscriptions, and CLI/MCP code duplication
- **`/perf`** -- Performance audit covering bundle size analysis for all 4 build outputs, dependency weight assessment (sharp, @anthropic-ai/sdk, keytar, whisper-node, zod v4), Electron-specific anti-patterns (startup latency, IPC payload size, setInterval leaks, renderer re-renders), pipeline hot path analysis (FrameExtractor ffmpeg spawns, ImageOptimizer sharp chaining, parallelization), and CLI/MCP cold start time
- **`/security`** -- Electron security audit with markupr's threat model (API keys, recordings, Whisper binary downloads, MCP server, auto-updater), preload script API surface review, IPC handler input validation (path traversal, command injection via ffmpeg/Whisper), network security (HTTPS, model checksum verification), and OWASP Desktop Top 10 checklist

These complement the existing commands (`/audit`, `/release-check`, `/test`, `/pick-task`, `/review-feedback`) without duplicating them. Each command references actual file paths, actual dependency names, and actual architecture patterns from the markupr codebase.

## Test plan

- [ ] Run `/ship` and verify it produces a go/no-go verdict with all 10 checks
- [ ] Run `/refactor src/main/pipeline/` and verify it establishes a test baseline before making changes
- [ ] Run `/perf` and verify it measures actual bundle sizes and identifies Electron-specific issues
- [ ] Run `/security` and verify it produces the OWASP Desktop Top 10 checklist with PASS/FAIL verdicts

Generated with [Claude Code](https://claude.com/claude-code)