### PR TITLE
Add deprecation redirect to markupr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> **This project has moved.** FeedbackFlow has been rebranded and evolved into **[markupr](https://github.com/eddiesanjuan/markupr)** -- with cross-platform support, a CLI, an MCP server for AI coding agents, and an intelligent post-processing pipeline. All future development happens at [github.com/eddiesanjuan/markupr](https://github.com/eddiesanjuan/markupr).
+>
+> **Install:** `npm install -g markupr` | **Download:** [markupr.com](https://markupr.com) | **Releases:** [github.com/eddiesanjuan/markupr/releases](https://github.com/eddiesanjuan/markupr/releases)
+
+---
+
 <p align="center">
   <img src="src/renderer/assets/logo.svg" alt="markupr Logo" width="120" height="120">
 </p>


### PR DESCRIPTION
## Summary
- Adds a prominent deprecation banner at the top of README.md directing visitors from the old `feedbackflow` URL to the canonical `markupr` repository
- GitHub already redirects `eddiesanjuan/feedbackflow` to `eddiesanjuan/markupr`, but the README had no context for the name change

## Context
FeedbackFlow was rebranded to markupr on Feb 7, 2026. The GitHub repo was renamed (automatic redirect active), but the README lacked any mention of the migration for visitors arriving via old links, bookmarks, or search results.

## Test plan
- [ ] Verify the banner renders correctly on the repo landing page
- [ ] Confirm all links in the banner resolve (markupr repo, markupr.com, releases page, npm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)