### PR TITLE
feat: Software Update section in Settings with manual check and local build fallback

### DIFF
--- a/src/main/AutoUpdater.ts
+++ b/src/main/AutoUpdater.ts
@@ -227,6 +227,18 @@ class AutoUpdaterManager {
     ipcMain.handle(IPC_CHANNELS.UPDATE_INSTALL, () => {
       return this.installUpdate();
     });
+
+    // Get current update state (used by Settings UI)
+    ipcMain.handle(IPC_CHANNELS.UPDATE_GET_STATUS, () => {
+      return {
+        status: this.state.status,
+        currentVersion: this.state.currentVersion,
+        availableVersion: this.state.availableVersion ?? null,
+        releaseNotes: this.state.releaseNotes ?? null,
+        downloadProgress: this.state.downloadProgress ?? null,
+        updaterAvailable: this.updaterAvailable,
+      };
+    });
   }
 
   /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1609,14 +1609,12 @@ app.whenReady().then(async () => {
     onError: handleSessionError,
   });
 
-  // 12. Initialize auto-updater (only in production)
-  if (process.env.NODE_ENV !== 'development') {
-    autoUpdaterManager.setAutoCheckEnabled(settingsManager.get('checkForUpdates'));
-    autoUpdaterManager.initialize(mainWindow!);
-    console.log('[Main] Auto-updater initialized');
-  } else {
-    console.log('[Main] Auto-updater skipped (development mode)');
-  }
+  // 12. Initialize auto-updater
+  // Always initialize so IPC handlers are registered and Settings UI can show
+  // update status. The updater internally disables itself for dev/unpackaged builds.
+  autoUpdaterManager.setAutoCheckEnabled(settingsManager.get('checkForUpdates'));
+  autoUpdaterManager.initialize(mainWindow!);
+  console.log('[Main] Auto-updater initialized');
 
   // 13. Check permissions on startup (macOS only)
   // Delay slightly to ensure window is fully ready

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -827,6 +827,20 @@ const markuprApi = {
     },
 
     /**
+     * Get current update state (version info, availability, etc.)
+     */
+    getStatus: (): Promise<{
+      status: string;
+      currentVersion: string;
+      availableVersion: string | null;
+      releaseNotes: string | null;
+      downloadProgress: number | null;
+      updaterAvailable: boolean;
+    }> => {
+      return ipcRenderer.invoke(IPC_CHANNELS.UPDATE_GET_STATUS);
+    },
+
+    /**
      * Subscribe to update status changes
      */
     onStatus: (callback: (status: UpdateStatusPayload) => void): Unsubscribe => {

--- a/src/renderer/components/settings/GeneralTab.tsx
+++ b/src/renderer/components/settings/GeneralTab.tsx
@@ -1,7 +1,392 @@
-import React from 'react';
-import type { AppSettings } from '../../../shared/types';
+import React, { useState, useEffect, useCallback } from 'react';
+import type { AppSettings, UpdateStatusPayload } from '../../../shared/types';
 import { SettingsSection, ToggleSetting, DirectoryPicker } from '../primitives';
 import { styles } from './settingsStyles';
+
+// =============================================================================
+// Update Status State
+// =============================================================================
+
+interface UpdateStatusState {
+  status: string;
+  currentVersion: string;
+  availableVersion: string | null;
+  releaseNotes: string | null;
+  downloadProgress: number | null;
+  updaterAvailable: boolean;
+}
+
+// =============================================================================
+// Software Update Section Component
+// =============================================================================
+
+const SoftwareUpdateSection: React.FC<{
+  checkForUpdates: boolean;
+  onCheckForUpdatesChange: (value: boolean) => void;
+}> = ({ checkForUpdates, onCheckForUpdatesChange }) => {
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatusState | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const [lastCheckResult, setLastCheckResult] = useState<'up-to-date' | 'available' | 'error' | null>(null);
+
+  // Load initial update status
+  useEffect(() => {
+    let cancelled = false;
+    const load = async (): Promise<void> => {
+      try {
+        const status = await window.markupr.updates.getStatus();
+        if (!cancelled) {
+          setUpdateStatus(status);
+        }
+      } catch {
+        // getStatus not available (older main process), show graceful fallback
+      }
+    };
+    void load();
+
+    // Subscribe to live update status changes
+    const unsubscribe = window.markupr.updates.onStatus((payload: UpdateStatusPayload) => {
+      if (cancelled) return;
+      setUpdateStatus((prev) => {
+        if (!prev) return null;
+        return {
+          ...prev,
+          status: payload.status,
+          availableVersion: payload.version ?? prev.availableVersion,
+          releaseNotes: payload.releaseNotes ?? prev.releaseNotes,
+          downloadProgress: payload.percent ?? prev.downloadProgress,
+        };
+      });
+
+      if (payload.status === 'available') {
+        setLastCheckResult('available');
+        setIsChecking(false);
+      } else if (payload.status === 'not-available') {
+        setLastCheckResult('up-to-date');
+        setIsChecking(false);
+      } else if (payload.status === 'error') {
+        setLastCheckResult('error');
+        setIsChecking(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  const handleCheckNow = useCallback(async () => {
+    setIsChecking(true);
+    setLastCheckResult(null);
+    try {
+      await window.markupr.updates.check();
+      // Result comes via the onStatus subscription above
+      // Set a timeout in case no response comes
+      setTimeout(() => {
+        setIsChecking((prev) => {
+          if (prev) {
+            setLastCheckResult('up-to-date');
+            return false;
+          }
+          return prev;
+        });
+      }, 10000);
+    } catch {
+      setIsChecking(false);
+      setLastCheckResult('error');
+    }
+  }, []);
+
+  const handleDownload = useCallback(async () => {
+    try {
+      await window.markupr.updates.download();
+    } catch {
+      // Error will come through onStatus
+    }
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    try {
+      await window.markupr.updates.install();
+    } catch {
+      // Error will come through onStatus
+    }
+  }, []);
+
+  const currentVersion = updateStatus?.currentVersion ?? '';
+  const availableVersion = updateStatus?.availableVersion;
+  const updaterAvailable = updateStatus?.updaterAvailable ?? false;
+  const liveStatus = updateStatus?.status ?? 'idle';
+
+  return (
+    <SettingsSection
+      title="Software Update"
+      description="Keep markupr up to date"
+    >
+      {/* Version Info */}
+      <div style={styles.settingRow}>
+        <div style={styles.settingInfo}>
+          <span style={styles.settingLabel}>Current Version</span>
+          <span style={styles.settingDescription}>
+            {currentVersion ? `v${currentVersion}` : 'Loading...'}
+          </span>
+        </div>
+      </div>
+
+      {/* Update status display */}
+      {availableVersion && liveStatus === 'available' && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: 12,
+          backgroundColor: 'rgba(59, 130, 246, 0.08)',
+          borderRadius: 8,
+          border: '1px solid rgba(59, 130, 246, 0.2)',
+        }}>
+          <div style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            backgroundColor: '#3b82f6',
+            flexShrink: 0,
+          }} />
+          <div style={{ flex: 1 }}>
+            <span style={{
+              display: 'block',
+              fontSize: 14,
+              fontWeight: 600,
+              color: 'var(--text-primary)',
+            }}>
+              Update Available: v{availableVersion}
+            </span>
+            <span style={{
+              display: 'block',
+              fontSize: 12,
+              color: 'var(--text-secondary)',
+              marginTop: 2,
+            }}>
+              A new version of markupr is ready to download.
+            </span>
+          </div>
+          <button
+            style={{
+              padding: '8px 16px',
+              backgroundColor: '#3b82f6',
+              border: 'none',
+              borderRadius: 8,
+              color: '#ffffff',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+              whiteSpace: 'nowrap',
+            }}
+            onClick={handleDownload}
+          >
+            Download
+          </button>
+        </div>
+      )}
+
+      {/* Download progress */}
+      {liveStatus === 'downloading' && (
+        <div style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          padding: 12,
+          backgroundColor: 'rgba(59, 130, 246, 0.08)',
+          borderRadius: 8,
+          border: '1px solid rgba(59, 130, 246, 0.2)',
+        }}>
+          <span style={{
+            fontSize: 13,
+            fontWeight: 500,
+            color: 'var(--text-primary)',
+          }}>
+            Downloading update...
+          </span>
+          <div style={{
+            height: 4,
+            backgroundColor: 'rgba(124, 137, 160, 0.3)',
+            borderRadius: 2,
+            overflow: 'hidden',
+          }}>
+            <div style={{
+              height: '100%',
+              backgroundColor: '#3b82f6',
+              borderRadius: 2,
+              transition: 'width 0.3s ease',
+              width: `${updateStatus?.downloadProgress ?? 0}%`,
+            }} />
+          </div>
+          <span style={{
+            fontSize: 12,
+            color: 'var(--text-tertiary)',
+            textAlign: 'right',
+          }}>
+            {Math.round(updateStatus?.downloadProgress ?? 0)}%
+          </span>
+        </div>
+      )}
+
+      {/* Ready to install */}
+      {liveStatus === 'ready' && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: 12,
+          backgroundColor: 'rgba(34, 197, 94, 0.08)',
+          borderRadius: 8,
+          border: '1px solid rgba(34, 197, 94, 0.2)',
+        }}>
+          <div style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            backgroundColor: '#22c55e',
+            flexShrink: 0,
+          }} />
+          <div style={{ flex: 1 }}>
+            <span style={{
+              display: 'block',
+              fontSize: 14,
+              fontWeight: 600,
+              color: 'var(--text-primary)',
+            }}>
+              Update Ready to Install
+            </span>
+            <span style={{
+              display: 'block',
+              fontSize: 12,
+              color: 'var(--text-secondary)',
+              marginTop: 2,
+            }}>
+              Restart markupr to apply the update. Your work will be saved.
+            </span>
+          </div>
+          <button
+            style={{
+              padding: '8px 16px',
+              backgroundColor: '#22c55e',
+              border: 'none',
+              borderRadius: 8,
+              color: '#ffffff',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+              whiteSpace: 'nowrap',
+            }}
+            onClick={handleInstall}
+          >
+            Restart Now
+          </button>
+        </div>
+      )}
+
+      {/* Up-to-date confirmation (after manual check) */}
+      {lastCheckResult === 'up-to-date' && liveStatus !== 'available' && liveStatus !== 'ready' && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 12px',
+          backgroundColor: 'rgba(34, 197, 94, 0.08)',
+          borderRadius: 8,
+          border: '1px solid rgba(34, 197, 94, 0.15)',
+        }}>
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M3.5 7l2.5 2.5 4.5-5" stroke="#22c55e" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span style={{ fontSize: 13, color: '#22c55e', fontWeight: 500 }}>
+            You are up to date
+          </span>
+        </div>
+      )}
+
+      {/* Error after manual check */}
+      {lastCheckResult === 'error' && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 12px',
+          backgroundColor: 'rgba(239, 68, 68, 0.08)',
+          borderRadius: 8,
+          border: '1px solid rgba(239, 68, 68, 0.15)',
+        }}>
+          <span style={{ fontSize: 13, color: 'var(--status-error)', fontWeight: 500 }}>
+            Unable to check for updates. Please try again later.
+          </span>
+        </div>
+      )}
+
+      {/* Updater unavailable (dev/local build) */}
+      {updateStatus && !updaterAvailable && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 12px',
+          backgroundColor: 'rgba(245, 158, 11, 0.08)',
+          borderRadius: 8,
+          border: '1px solid rgba(245, 158, 11, 0.15)',
+        }}>
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M7 4.5v3M7 9.5h.005" stroke="#f59e0b" strokeWidth="1.5" strokeLinecap="round" />
+            <circle cx="7" cy="7" r="5.5" stroke="#f59e0b" strokeWidth="1" />
+          </svg>
+          <span style={{ fontSize: 12, color: 'var(--text-tertiary)' }}>
+            Auto-updates unavailable (local build). Download the latest release from{' '}
+            <a
+              href="https://github.com/eddiesanjuan/markupr/releases"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'var(--text-link)', textDecoration: 'underline' }}
+            >
+              GitHub Releases
+            </a>.
+          </span>
+        </div>
+      )}
+
+      {/* Auto-check toggle */}
+      <ToggleSetting
+        label="Check Automatically"
+        description="Check for updates on launch and periodically while running"
+        value={checkForUpdates}
+        onChange={onCheckForUpdatesChange}
+        disabled={!updaterAvailable && updateStatus !== null}
+      />
+
+      {/* Check Now button */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <button
+          style={{
+            ...styles.secondaryButton,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            opacity: isChecking || (!updaterAvailable && updateStatus !== null) ? 0.5 : 1,
+            cursor: isChecking || (!updaterAvailable && updateStatus !== null) ? 'not-allowed' : 'pointer',
+          }}
+          onClick={handleCheckNow}
+          disabled={isChecking || (!updaterAvailable && updateStatus !== null)}
+        >
+          {isChecking && (
+            <span style={styles.spinner} />
+          )}
+          {isChecking ? 'Checking...' : 'Check for Updates'}
+        </button>
+      </div>
+    </SettingsSection>
+  );
+};
+
+// =============================================================================
+// General Tab (exported)
+// =============================================================================
 
 export const GeneralTab: React.FC<{
   settings: AppSettings;
@@ -9,6 +394,11 @@ export const GeneralTab: React.FC<{
   onResetSection: () => void;
 }> = ({ settings, onSettingChange, onResetSection }) => (
   <div style={styles.tabContent}>
+    <SoftwareUpdateSection
+      checkForUpdates={settings.checkForUpdates}
+      onCheckForUpdatesChange={(value) => onSettingChange('checkForUpdates', value)}
+    />
+
     <SettingsSection
       title="Output"
       description="Where your feedback sessions are saved"
@@ -28,12 +418,6 @@ export const GeneralTab: React.FC<{
         description="Start markupr automatically when you log in"
         value={settings.launchAtLogin}
         onChange={(value) => onSettingChange('launchAtLogin', value)}
-      />
-      <ToggleSetting
-        label="Check for Updates"
-        description="Automatically check on launch and while the app is running"
-        value={settings.checkForUpdates}
-        onChange={(value) => onSettingChange('checkForUpdates', value)}
       />
     </SettingsSection>
   </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -345,6 +345,7 @@ export const IPC_CHANNELS = {
   UPDATE_CHECK: 'markupr:update:check',
   UPDATE_DOWNLOAD: 'markupr:update:download',
   UPDATE_INSTALL: 'markupr:update:install',
+  UPDATE_GET_STATUS: 'markupr:update:get-status',
 
   // ---------------------------------------------------------------------------
   // Update Channels (Main -> Renderer)

--- a/tests/unit/autoUpdater.test.ts
+++ b/tests/unit/autoUpdater.test.ts
@@ -1,0 +1,504 @@
+/**
+ * AutoUpdater Unit Tests
+ *
+ * Tests the auto-update system:
+ * - canUseUpdater() logic (packaged vs unpackaged)
+ * - IPC handler registration including UPDATE_GET_STATUS
+ * - Update state management
+ * - Silent failure modes and user feedback
+ * - Error suppression for expected update errors
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IPC_CHANNELS } from '../../src/shared/types';
+
+// =============================================================================
+// Mock electron-updater before any imports
+// =============================================================================
+
+const mockAutoUpdater = {
+  checkForUpdates: vi.fn(() => Promise.resolve(null)),
+  downloadUpdate: vi.fn(() => Promise.resolve([])),
+  quitAndInstall: vi.fn(),
+  on: vi.fn(),
+  once: vi.fn(),
+  removeAllListeners: vi.fn(),
+  setFeedURL: vi.fn(),
+  logger: null as unknown,
+  autoDownload: false,
+  autoInstallOnAppQuit: true,
+  allowDowngrade: false,
+  allowPrerelease: false,
+};
+
+vi.mock('electron-updater', () => ({
+  default: { autoUpdater: mockAutoUpdater },
+  autoUpdater: mockAutoUpdater,
+}));
+
+// =============================================================================
+// IPC Channel Tests
+// =============================================================================
+
+describe('AutoUpdater IPC Channels', () => {
+  it('defines UPDATE_GET_STATUS channel', () => {
+    expect(IPC_CHANNELS.UPDATE_GET_STATUS).toBe('markupr:update:get-status');
+  });
+
+  it('defines all required update channels', () => {
+    expect(IPC_CHANNELS.UPDATE_CHECK).toBe('markupr:update:check');
+    expect(IPC_CHANNELS.UPDATE_DOWNLOAD).toBe('markupr:update:download');
+    expect(IPC_CHANNELS.UPDATE_INSTALL).toBe('markupr:update:install');
+    expect(IPC_CHANNELS.UPDATE_STATUS).toBe('markupr:update:status');
+    expect(IPC_CHANNELS.UPDATE_GET_STATUS).toBe('markupr:update:get-status');
+  });
+});
+
+// =============================================================================
+// Testable AutoUpdater Manager (isolated from Electron dependencies)
+// =============================================================================
+
+type UpdateStatusType =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'not-available'
+  | 'downloading'
+  | 'ready'
+  | 'error';
+
+interface UpdateManagerState {
+  status: UpdateStatusType;
+  currentVersion: string;
+  availableVersion?: string;
+  releaseNotes?: string | null;
+  downloadProgress?: number;
+}
+
+/**
+ * Testable version of AutoUpdaterManager that replaces Electron dependencies
+ * with injectable test doubles.
+ */
+class TestableAutoUpdaterManager {
+  private state: UpdateManagerState;
+  private initialized = false;
+  private updaterAvailable = false;
+  private autoCheckEnabled = true;
+  private isChecking = false;
+  private ipcHandlers = new Map<string, (...args: unknown[]) => unknown>();
+  private sentStatuses: Array<{ status: string; data?: unknown }> = [];
+
+  constructor(
+    private readonly isPackaged: boolean,
+    private readonly appUpdateYmlExists: boolean,
+    private readonly currentVersion = '2.1.0',
+  ) {
+    this.state = {
+      status: 'idle',
+      currentVersion: this.currentVersion,
+    };
+  }
+
+  initialize(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.updaterAvailable = this.canUseUpdater();
+    this.setupIPCHandlers();
+
+    if (!this.updaterAvailable) {
+      this.updateState('not-available');
+      return;
+    }
+  }
+
+  private canUseUpdater(): boolean {
+    if (!this.isPackaged) return false;
+    return this.appUpdateYmlExists;
+  }
+
+  private setupIPCHandlers(): void {
+    this.ipcHandlers.set(IPC_CHANNELS.UPDATE_CHECK, async () => {
+      return this.checkForUpdates();
+    });
+
+    this.ipcHandlers.set(IPC_CHANNELS.UPDATE_DOWNLOAD, async () => {
+      return this.downloadUpdate();
+    });
+
+    this.ipcHandlers.set(IPC_CHANNELS.UPDATE_INSTALL, () => {
+      return this.installUpdate();
+    });
+
+    this.ipcHandlers.set(IPC_CHANNELS.UPDATE_GET_STATUS, () => {
+      return {
+        status: this.state.status,
+        currentVersion: this.state.currentVersion,
+        availableVersion: this.state.availableVersion ?? null,
+        releaseNotes: this.state.releaseNotes ?? null,
+        downloadProgress: this.state.downloadProgress ?? null,
+        updaterAvailable: this.updaterAvailable,
+      };
+    });
+  }
+
+  async checkForUpdates(): Promise<unknown> {
+    if (!this.updaterAvailable) {
+      this.updateState('not-available');
+      return null;
+    }
+    if (this.isChecking) return null;
+
+    this.isChecking = true;
+    this.updateState('checking');
+
+    try {
+      return await mockAutoUpdater.checkForUpdates();
+    } finally {
+      this.isChecking = false;
+    }
+  }
+
+  async downloadUpdate(): Promise<void> {
+    if (!this.updaterAvailable) {
+      this.updateState('not-available');
+      return;
+    }
+    this.updateState('downloading');
+    await mockAutoUpdater.downloadUpdate();
+  }
+
+  installUpdate(): void {
+    if (!this.updaterAvailable) {
+      this.updateState('not-available');
+      return;
+    }
+    mockAutoUpdater.quitAndInstall(false, true);
+  }
+
+  setAutoCheckEnabled(enabled: boolean): void {
+    this.autoCheckEnabled = enabled;
+  }
+
+  // Simulate receiving an update-available event
+  simulateUpdateAvailable(version: string, notes?: string): void {
+    this.state.availableVersion = version;
+    this.state.releaseNotes = notes ?? null;
+    this.updateState('available');
+  }
+
+  // Simulate receiving an update-downloaded event
+  simulateUpdateDownloaded(version: string): void {
+    this.state.availableVersion = version;
+    this.updateState('ready');
+  }
+
+  private updateState(status: UpdateStatusType): void {
+    this.state.status = status;
+    this.sentStatuses.push({ status, data: { ...this.state } });
+  }
+
+  // Test helpers
+  getState(): UpdateManagerState {
+    return { ...this.state };
+  }
+
+  isUpdaterAvailable(): boolean {
+    return this.updaterAvailable;
+  }
+
+  getIPCHandler(channel: string): ((...args: unknown[]) => unknown) | undefined {
+    return this.ipcHandlers.get(channel);
+  }
+
+  getSentStatuses(): Array<{ status: string; data?: unknown }> {
+    return [...this.sentStatuses];
+  }
+
+  isAutoCheckEnabled(): boolean {
+    return this.autoCheckEnabled;
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AutoUpdaterManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Initialization & canUseUpdater()
+  // ---------------------------------------------------------------------------
+
+  describe('canUseUpdater', () => {
+    it('returns false when app is not packaged', () => {
+      const manager = new TestableAutoUpdaterManager(false, true);
+      manager.initialize();
+      expect(manager.isUpdaterAvailable()).toBe(false);
+    });
+
+    it('returns false when app-update.yml is missing', () => {
+      const manager = new TestableAutoUpdaterManager(true, false);
+      manager.initialize();
+      expect(manager.isUpdaterAvailable()).toBe(false);
+    });
+
+    it('returns true when packaged and app-update.yml exists', () => {
+      const manager = new TestableAutoUpdaterManager(true, true);
+      manager.initialize();
+      expect(manager.isUpdaterAvailable()).toBe(true);
+    });
+  });
+
+  describe('initialization', () => {
+    it('sets status to not-available when updater is disabled', () => {
+      const manager = new TestableAutoUpdaterManager(false, false);
+      manager.initialize();
+      expect(manager.getState().status).toBe('not-available');
+    });
+
+    it('keeps status idle when updater is available', () => {
+      const manager = new TestableAutoUpdaterManager(true, true);
+      manager.initialize();
+      // After init with updater available, status stays idle (checks happen later)
+      expect(manager.getState().status).toBe('idle');
+    });
+
+    it('registers IPC handlers even when updater is unavailable', () => {
+      const manager = new TestableAutoUpdaterManager(false, false);
+      manager.initialize();
+
+      expect(manager.getIPCHandler(IPC_CHANNELS.UPDATE_CHECK)).toBeDefined();
+      expect(manager.getIPCHandler(IPC_CHANNELS.UPDATE_DOWNLOAD)).toBeDefined();
+      expect(manager.getIPCHandler(IPC_CHANNELS.UPDATE_INSTALL)).toBeDefined();
+      expect(manager.getIPCHandler(IPC_CHANNELS.UPDATE_GET_STATUS)).toBeDefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // UPDATE_GET_STATUS Handler
+  // ---------------------------------------------------------------------------
+
+  describe('UPDATE_GET_STATUS', () => {
+    it('returns full state including updaterAvailable flag', () => {
+      const manager = new TestableAutoUpdaterManager(true, true, '2.1.0');
+      manager.initialize();
+
+      const handler = manager.getIPCHandler(IPC_CHANNELS.UPDATE_GET_STATUS);
+      expect(handler).toBeDefined();
+
+      const result = handler!() as {
+        status: string;
+        currentVersion: string;
+        availableVersion: string | null;
+        releaseNotes: string | null;
+        downloadProgress: number | null;
+        updaterAvailable: boolean;
+      };
+
+      expect(result.status).toBe('idle');
+      expect(result.currentVersion).toBe('2.1.0');
+      expect(result.availableVersion).toBe(null);
+      expect(result.releaseNotes).toBe(null);
+      expect(result.downloadProgress).toBe(null);
+      expect(result.updaterAvailable).toBe(true);
+    });
+
+    it('reports updaterAvailable=false for unpackaged builds', () => {
+      const manager = new TestableAutoUpdaterManager(false, false, '2.1.0');
+      manager.initialize();
+
+      const handler = manager.getIPCHandler(IPC_CHANNELS.UPDATE_GET_STATUS);
+      const result = handler!() as { updaterAvailable: boolean; status: string };
+
+      expect(result.updaterAvailable).toBe(false);
+      expect(result.status).toBe('not-available');
+    });
+
+    it('includes available version after update-available event', () => {
+      const manager = new TestableAutoUpdaterManager(true, true, '2.1.0');
+      manager.initialize();
+      manager.simulateUpdateAvailable('2.5.0', 'Bug fixes and improvements');
+
+      const handler = manager.getIPCHandler(IPC_CHANNELS.UPDATE_GET_STATUS);
+      const result = handler!() as {
+        status: string;
+        availableVersion: string | null;
+        releaseNotes: string | null;
+      };
+
+      expect(result.status).toBe('available');
+      expect(result.availableVersion).toBe('2.5.0');
+      expect(result.releaseNotes).toBe('Bug fixes and improvements');
+    });
+
+    it('reports ready status after update download', () => {
+      const manager = new TestableAutoUpdaterManager(true, true, '2.1.0');
+      manager.initialize();
+      manager.simulateUpdateDownloaded('2.5.0');
+
+      const handler = manager.getIPCHandler(IPC_CHANNELS.UPDATE_GET_STATUS);
+      const result = handler!() as { status: string; availableVersion: string | null };
+
+      expect(result.status).toBe('ready');
+      expect(result.availableVersion).toBe('2.5.0');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // checkForUpdates
+  // ---------------------------------------------------------------------------
+
+  describe('checkForUpdates', () => {
+    it('returns null and sets not-available when updater is disabled', async () => {
+      const manager = new TestableAutoUpdaterManager(false, false);
+      manager.initialize();
+
+      const result = await manager.checkForUpdates();
+      expect(result).toBeNull();
+      expect(manager.getState().status).toBe('not-available');
+    });
+
+    it('calls autoUpdater.checkForUpdates when updater is available', async () => {
+      const manager = new TestableAutoUpdaterManager(true, true);
+      manager.initialize();
+
+      await manager.checkForUpdates();
+      expect(mockAutoUpdater.checkForUpdates).toHaveBeenCalledOnce();
+    });
+
+    it('prevents concurrent checks', async () => {
+      const manager = new TestableAutoUpdaterManager(true, true);
+      manager.initialize();
+
+      // Start two concurrent checks
+      const p1 = manager.checkForUpdates();
+      const p2 = manager.checkForUpdates();
+
+      await Promise.all([p1, p2]);
+
+      // Only one actual check should have been made
+      expect(mockAutoUpdater.checkForUpdates).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // downloadUpdate
+  // ---------------------------------------------------------------------------
+
+  describe('downloadUpdate', () => {
+    it('does nothing when updater is disabled', async () => {
+      const manager = new TestableAutoUpdaterManager(false, false);
+      manager.initialize();
+
+      await manager.downloadUpdate();
+      expect(mockAutoUpdater.downloadUpdate).not.toHaveBeenCalled();
+      expect(manager.getState().status).toBe('not-available');
+    });
+
+    it('starts download when updater is available', async () => {
+      const manager = new TestableAutoUpdaterManager(true, true);
+      manager.initialize();
+
+      await manager.downloadUpdate();
+      expect(mockAutoUpdater.downloadUpdate).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // installUpdate
+  // ---------------------------------------------------------------------------
+
+  describe('installUpdate', () => {
+    it('does nothing when updater is disabled', () => {
+      const manager = new TestableAutoUpdaterManager(false, false);
+      manager.initialize();
+
+      manager.installUpdate();
+      expect(mockAutoUpdater.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it('calls quitAndInstall when updater is available', () => {
+      const manager = new TestableAutoUpdaterManager(true, true);
+      manager.initialize();
+
+      manager.installUpdate();
+      expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auto-check enabled/disabled
+  // ---------------------------------------------------------------------------
+
+  describe('setAutoCheckEnabled', () => {
+    it('can enable and disable auto-checks', () => {
+      const manager = new TestableAutoUpdaterManager(true, true);
+      manager.initialize();
+
+      manager.setAutoCheckEnabled(false);
+      expect(manager.isAutoCheckEnabled()).toBe(false);
+
+      manager.setAutoCheckEnabled(true);
+      expect(manager.isAutoCheckEnabled()).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // State management
+  // ---------------------------------------------------------------------------
+
+  describe('state transitions', () => {
+    it('tracks version through complete update lifecycle', () => {
+      const manager = new TestableAutoUpdaterManager(true, true, '2.1.0');
+      manager.initialize();
+
+      expect(manager.getState().currentVersion).toBe('2.1.0');
+      expect(manager.getState().status).toBe('idle');
+
+      manager.simulateUpdateAvailable('2.5.0');
+      expect(manager.getState().status).toBe('available');
+      expect(manager.getState().availableVersion).toBe('2.5.0');
+
+      manager.simulateUpdateDownloaded('2.5.0');
+      expect(manager.getState().status).toBe('ready');
+    });
+  });
+});
+
+// =============================================================================
+// Error Suppression Logic
+// =============================================================================
+
+describe('Error suppression', () => {
+  const suppressableErrors = [
+    'Error: Cannot find module app-update.yml',
+    'Error: HttpError: 404 - latest.yml not found',
+    'ENOENT: no such file or directory',
+  ];
+
+  const nonSuppressableErrors = [
+    'Error: Network request failed',
+    'Error: Update download failed',
+    'Error: EPERM: operation not permitted',
+  ];
+
+  function shouldSuppressUpdateError(error: { message: string }): boolean {
+    const message = error.message.toLowerCase();
+    return (
+      message.includes('app-update.yml') ||
+      message.includes('latest.yml') ||
+      message.includes('enoent')
+    );
+  }
+
+  it.each(suppressableErrors)('suppresses expected error: %s', (errorMessage) => {
+    expect(shouldSuppressUpdateError({ message: errorMessage })).toBe(true);
+  });
+
+  it.each(nonSuppressableErrors)('does not suppress unexpected error: %s', (errorMessage) => {
+    expect(shouldSuppressUpdateError({ message: errorMessage })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **Software Update** section to Settings > General showing current version, update availability, download progress, and restart-to-install
- Adds a **"Check for Updates"** button for manual checks with loading spinner and timeout
- Shows **amber warning for local/dev builds** ("Auto-updates unavailable") with direct link to GitHub Releases
- Always registers auto-updater IPC handlers (even in dev) so the Settings UI never hits unhandled errors
- Adds `UPDATE_GET_STATUS` IPC channel so renderer can query full update state on mount

## Problem
Users on local/unsigned builds (like Eddie on v2.1.0) had **zero indication** updates existed. The auto-updater silently disabled itself with no UI feedback. There was no manual "Check for Updates" button and no version/update status anywhere in Settings.

## Test plan
- [ ] Verify Settings > General shows "Software Update" section with current version
- [ ] Verify "Check for Updates" button triggers a check with loading spinner
- [ ] Verify local/dev builds show amber "Auto-updates unavailable" warning with GitHub Releases link
- [ ] Verify the toggle and button are disabled for local builds
- [ ] Verify 27 new unit tests pass (`npm test -- --run tests/unit/autoUpdater.test.ts`)
- [ ] Verify full test suite passes (887 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)