### PR TITLE
feat(mcp): add describe_screen tool for AI visual context

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,6 +16,7 @@ import { register as registerStartRecording } from './tools/startRecording.js';
 import { register as registerStopRecording } from './tools/stopRecording.js';
 import { register as registerPushToLinear } from './tools/pushToLinear.js';
 import { register as registerPushToGitHub } from './tools/pushToGitHub.js';
+import { register as registerDescribeScreen } from './tools/describeScreen.js';
 
 // Resource registrations
 import { registerResources } from './resources/sessionResource.js';
@@ -40,6 +41,7 @@ export function createServer(): McpServer {
   registerStopRecording(server);
   registerPushToLinear(server);
   registerPushToGitHub(server);
+  registerDescribeScreen(server);
 
   // Register resources (session://latest, session://{id})
   registerResources(server);

--- a/src/mcp/tools/describeScreen.ts
+++ b/src/mcp/tools/describeScreen.ts
@@ -1,0 +1,287 @@
+/**
+ * Tool: describe_screen
+ *
+ * Captures a screenshot (or reads a provided image path) and uses Claude's
+ * vision API to produce a structured text description of what is visible on
+ * screen. Designed to give AI coding agents rich visual context: UI elements,
+ * text content, layout structure, active windows, error messages, etc.
+ *
+ * Works in headless mode -- no Electron dependency.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { join } from 'path';
+import { readFile, unlink, stat } from 'fs/promises';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+import Anthropic from '@anthropic-ai/sdk';
+import { capture } from '../capture/ScreenCapture.js';
+import { optimize } from '../utils/ImageOptimizer.js';
+import { log } from '../utils/Logger.js';
+
+// ---------------------------------------------------------------------------
+// System prompt -- instructs Claude to produce a structured screen description
+// ---------------------------------------------------------------------------
+
+const DESCRIBE_SCREEN_PROMPT = `You are a screen description engine for AI coding agents. You receive a screenshot of a developer's screen and must describe what is visible in a structured, actionable way.
+
+## Output Structure
+
+Return a structured description with the following sections:
+
+### Active Window
+Identify the primary/focused application and its state (e.g., "VS Code with main.ts open", "Chrome showing localhost:3000").
+
+### Visible UI Elements
+List the key UI elements visible: buttons, inputs, navigation, modals, dialogs, sidebars, tabs, toolbars, etc. Be specific about labels and state (enabled/disabled, selected, etc.).
+
+### Text Content
+Extract any readable text: error messages, code snippets, terminal output, form content, headings, notifications, toasts, etc. Quote verbatim when possible.
+
+### Layout Structure
+Briefly describe the spatial layout: panels, split views, columns, overlays, etc.
+
+### Notable Issues
+Flag anything that looks like a problem: error dialogs, red indicators, broken layouts, console errors, failed builds, stack traces, etc. If nothing looks wrong, say "None observed."
+
+## Rules
+1. Be factual and precise. Describe what you SEE, do not speculate about intent.
+2. Use developer-friendly terminology (e.g., "modal dialog" not "popup box").
+3. If text is partially obscured, note what is readable and indicate truncation with [...].
+4. Keep the description concise but thorough. Every line should be useful to an AI agent trying to understand the screen context.
+5. Do not wrap your response in markdown code fences. Return plain structured text.`;
+
+// ---------------------------------------------------------------------------
+// Tool Registration
+// ---------------------------------------------------------------------------
+
+export function register(server: McpServer): void {
+  server.tool(
+    'describe_screen',
+    'Capture a screenshot (or read an existing image) and return a structured text description of what is visible on screen. Useful for giving AI agents visual context about UI state, errors, layout, and text content.',
+    {
+      imagePath: z
+        .string()
+        .optional()
+        .describe(
+          'Absolute path to an existing screenshot/image file. If omitted, a fresh screenshot is captured.',
+        ),
+      display: z
+        .number()
+        .optional()
+        .default(1)
+        .describe('Display number to capture (1-indexed). Ignored when imagePath is provided.'),
+      apiKey: z
+        .string()
+        .optional()
+        .describe(
+          'Anthropic API key. Falls back to ANTHROPIC_API_KEY env var.',
+        ),
+      focus: z
+        .string()
+        .optional()
+        .describe(
+          'Optional focus area to pay extra attention to (e.g., "the error dialog", "the terminal output", "the sidebar navigation").',
+        ),
+    },
+    async ({ imagePath, display, apiKey, focus }) => {
+      // Resolve API key
+      const resolvedKey = apiKey || process.env.ANTHROPIC_API_KEY;
+      if (!resolvedKey) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Error: No Anthropic API key provided. Pass via `apiKey` parameter or set ANTHROPIC_API_KEY env var.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      let screenshotPath: string | undefined;
+      let tempPath: string | undefined;
+
+      try {
+        // -----------------------------------------------------------------
+        // Step 1: Obtain the screenshot
+        // -----------------------------------------------------------------
+        if (imagePath) {
+          // Validate provided image path
+          let fileStats;
+          try {
+            fileStats = await stat(imagePath);
+          } catch {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Error: Image file not found: ${imagePath}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          if (!fileStats.isFile() || fileStats.size === 0) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Error: Image file is empty or not a regular file: ${imagePath}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          screenshotPath = imagePath;
+        } else {
+          // Capture fresh screenshot
+          tempPath = join(
+            tmpdir(),
+            `markupr-mcp-describe-${randomUUID()}.png`,
+          );
+          log(`Capturing screenshot for describe_screen: display=${display}`);
+          await capture({ display, outputPath: tempPath });
+          await optimize(tempPath);
+          screenshotPath = tempPath;
+        }
+
+        // -----------------------------------------------------------------
+        // Step 2: Read image as base64
+        // -----------------------------------------------------------------
+        const imageBuffer = await readFile(screenshotPath!);
+        const base64Data = imageBuffer.toString('base64');
+
+        // Determine media type from extension
+        const ext = screenshotPath!.split('.').pop()?.toLowerCase();
+        const mediaType: 'image/png' | 'image/jpeg' | 'image/webp' | 'image/gif' =
+          ext === 'jpg' || ext === 'jpeg'
+            ? 'image/jpeg'
+            : ext === 'webp'
+              ? 'image/webp'
+              : ext === 'gif'
+                ? 'image/gif'
+                : 'image/png';
+
+        // -----------------------------------------------------------------
+        // Step 3: Call Claude vision API
+        // -----------------------------------------------------------------
+        log('Calling Claude API for screen description');
+
+        const client = new Anthropic({ apiKey: resolvedKey });
+
+        const userPrompt = focus
+          ? `Describe what is visible on this screen. Pay special attention to: ${focus}`
+          : 'Describe what is visible on this screen.';
+
+        const response = await client.messages.create({
+          model: 'claude-sonnet-4-5-20250929',
+          max_tokens: 2048,
+          temperature: 0.2,
+          system: DESCRIBE_SCREEN_PROMPT,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: mediaType,
+                    data: base64Data,
+                  },
+                },
+                {
+                  type: 'text',
+                  text: userPrompt,
+                },
+              ],
+            },
+          ],
+        });
+
+        // Extract text from response
+        const textBlock = response.content.find(
+          (block) => block.type === 'text',
+        );
+        if (!textBlock || textBlock.type !== 'text') {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: No text content in Claude response.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const timestamp = new Date().toISOString();
+        const source = imagePath
+          ? `image file: ${imagePath}`
+          : `display ${display} capture`;
+
+        log('Screen description complete');
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: [
+                `# Screen Description`,
+                `_Source: ${source} | ${timestamp}_`,
+                '',
+                textBlock.text,
+              ].join('\n'),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = (error as Error).message;
+
+        // Provide actionable error messages for common failures
+        if (message.includes('401') || message.includes('authentication')) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: Anthropic API authentication failed. Check your API key.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        if (message.includes('429') || message.includes('rate')) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: Anthropic API rate limit exceeded. Try again shortly.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      } finally {
+        // Clean up temp file if we created one
+        if (tempPath) {
+          await unlink(tempPath).catch(() => {});
+        }
+      }
+    },
+  );
+}

--- a/tests/unit/mcp/describeScreen.test.ts
+++ b/tests/unit/mcp/describeScreen.test.ts
@@ -1,0 +1,535 @@
+/**
+ * describeScreen Tool Unit Tests
+ *
+ * Tests the describe_screen MCP tool handler:
+ * - Registers tool with correct name
+ * - Returns error when no API key is available
+ * - Captures screenshot when no imagePath provided
+ * - Uses provided imagePath instead of capturing
+ * - Validates imagePath exists and is non-empty
+ * - Optimizes captured screenshots
+ * - Calls Claude API with correct model and prompt
+ * - Includes focus area in user prompt when provided
+ * - Returns structured text description
+ * - Returns isError on capture failure
+ * - Returns isError on Claude API failure
+ * - Cleans up temp file after success
+ * - Cleans up temp file on error
+ * - Returns actionable error for auth failures
+ * - Returns actionable error for rate limit
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// Hoisted mocks
+// =============================================================================
+
+const {
+  mockCapture,
+  mockOptimize,
+  mockReadFile,
+  mockUnlink,
+  mockStat,
+  mockMessagesCreate,
+} = vi.hoisted(() => ({
+  mockCapture: vi.fn(),
+  mockOptimize: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockUnlink: vi.fn(),
+  mockStat: vi.fn(),
+  mockMessagesCreate: vi.fn(),
+}));
+
+vi.mock('../../../src/mcp/capture/ScreenCapture.js', () => ({
+  capture: mockCapture,
+}));
+
+vi.mock('../../../src/mcp/utils/ImageOptimizer.js', () => ({
+  optimize: mockOptimize,
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: mockReadFile,
+  unlink: mockUnlink,
+  stat: mockStat,
+}));
+
+vi.mock('os', () => ({
+  tmpdir: () => '/tmp',
+}));
+
+vi.mock('crypto', () => ({
+  randomUUID: () => 'test-uuid-1234',
+}));
+
+vi.mock('../../../src/mcp/utils/Logger.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: mockMessagesCreate,
+    },
+  })),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    string: () => ({ optional: () => ({ describe: () => ({}) }) }),
+    number: () => ({
+      optional: () => ({ default: () => ({ describe: () => ({}) }) }),
+    }),
+    boolean: () => ({
+      optional: () => ({ default: () => ({ describe: () => ({}) }) }),
+    }),
+  },
+}));
+
+import { register } from '../../../src/mcp/tools/describeScreen.js';
+
+describe('describeScreen tool', () => {
+  let toolHandler: Function;
+  let mockServer: any;
+
+  const defaultClaudeResponse = {
+    content: [
+      {
+        type: 'text',
+        text: '### Active Window\nVS Code with index.ts open\n\n### Visible UI Elements\n- File explorer sidebar\n- Editor tab: index.ts\n\n### Text Content\nconst app = express();\n\n### Layout Structure\nTwo-panel layout with sidebar and editor\n\n### Notable Issues\nNone observed.',
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockServer = {
+      tool: vi.fn(
+        (_name: string, _desc: string, _schema: any, handler: Function) => {
+          toolHandler = handler;
+        },
+      ),
+    };
+
+    // Default mock implementations
+    mockCapture.mockResolvedValue(
+      '/tmp/markupr-mcp-describe-test-uuid-1234.png',
+    );
+    mockOptimize.mockResolvedValue(
+      '/tmp/markupr-mcp-describe-test-uuid-1234.png',
+    );
+    mockReadFile.mockResolvedValue(Buffer.from('fake-image-data'));
+    mockUnlink.mockResolvedValue(undefined);
+    mockStat.mockResolvedValue({ isFile: () => true, size: 1024 });
+    mockMessagesCreate.mockResolvedValue(defaultClaudeResponse);
+
+    // Set env var for most tests
+    process.env.ANTHROPIC_API_KEY = 'test-key-123';
+
+    register(mockServer);
+  });
+
+  // =========================================================================
+  // Registration
+  // =========================================================================
+
+  it('registers with correct tool name', () => {
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'describe_screen',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  // =========================================================================
+  // API Key Resolution
+  // =========================================================================
+
+  it('returns error when no API key is available', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const result = await toolHandler({
+      imagePath: undefined,
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No Anthropic API key');
+  });
+
+  it('uses apiKey parameter over env var', async () => {
+    const Anthropic = (await import('@anthropic-ai/sdk')).default;
+
+    await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: 'param-key-456',
+      focus: undefined,
+    });
+
+    expect(Anthropic).toHaveBeenCalledWith({ apiKey: 'param-key-456' });
+  });
+
+  it('falls back to ANTHROPIC_API_KEY env var', async () => {
+    const Anthropic = (await import('@anthropic-ai/sdk')).default;
+    process.env.ANTHROPIC_API_KEY = 'env-key-789';
+
+    await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(Anthropic).toHaveBeenCalledWith({ apiKey: 'env-key-789' });
+  });
+
+  // =========================================================================
+  // Screenshot Capture (no imagePath)
+  // =========================================================================
+
+  it('captures screenshot when no imagePath provided', async () => {
+    await toolHandler({
+      imagePath: undefined,
+      display: 2,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ display: 2 }),
+    );
+  });
+
+  it('optimizes captured screenshot', async () => {
+    await toolHandler({
+      imagePath: undefined,
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(mockOptimize).toHaveBeenCalledWith(
+      expect.stringContaining('markupr-mcp-describe'),
+    );
+  });
+
+  it('does not capture or optimize when imagePath is provided', async () => {
+    await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(mockCapture).not.toHaveBeenCalled();
+    expect(mockOptimize).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Image Path Validation
+  // =========================================================================
+
+  it('validates imagePath exists', async () => {
+    mockStat.mockRejectedValue(new Error('ENOENT'));
+
+    const result = await toolHandler({
+      imagePath: '/nonexistent/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Image file not found');
+  });
+
+  it('validates imagePath is a non-empty file', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 0 });
+
+    const result = await toolHandler({
+      imagePath: '/test/empty.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('empty or not a regular file');
+  });
+
+  it('validates imagePath is a regular file', async () => {
+    mockStat.mockResolvedValue({ isFile: () => false, size: 1024 });
+
+    const result = await toolHandler({
+      imagePath: '/test/directory',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('empty or not a regular file');
+  });
+
+  // =========================================================================
+  // Claude API Call
+  // =========================================================================
+
+  it('calls Claude API with correct model', async () => {
+    await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 2048,
+      }),
+    );
+  });
+
+  it('sends image as base64 in the API request', async () => {
+    mockReadFile.mockResolvedValue(Buffer.from('test-image-bytes'));
+
+    await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    const callArgs = mockMessagesCreate.mock.calls[0][0];
+    const imageBlock = callArgs.messages[0].content[0];
+
+    expect(imageBlock.type).toBe('image');
+    expect(imageBlock.source.type).toBe('base64');
+    expect(imageBlock.source.media_type).toBe('image/png');
+    expect(imageBlock.source.data).toBe(
+      Buffer.from('test-image-bytes').toString('base64'),
+    );
+  });
+
+  it('detects JPEG media type from extension', async () => {
+    await toolHandler({
+      imagePath: '/test/image.jpg',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    const callArgs = mockMessagesCreate.mock.calls[0][0];
+    const imageBlock = callArgs.messages[0].content[0];
+    expect(imageBlock.source.media_type).toBe('image/jpeg');
+  });
+
+  it('detects WebP media type from extension', async () => {
+    await toolHandler({
+      imagePath: '/test/image.webp',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    const callArgs = mockMessagesCreate.mock.calls[0][0];
+    const imageBlock = callArgs.messages[0].content[0];
+    expect(imageBlock.source.media_type).toBe('image/webp');
+  });
+
+  it('includes focus area in user prompt when provided', async () => {
+    await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: 'the error dialog',
+    });
+
+    const callArgs = mockMessagesCreate.mock.calls[0][0];
+    const textBlock = callArgs.messages[0].content[1];
+    expect(textBlock.text).toContain('the error dialog');
+  });
+
+  it('uses generic prompt when no focus provided', async () => {
+    await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    const callArgs = mockMessagesCreate.mock.calls[0][0];
+    const textBlock = callArgs.messages[0].content[1];
+    expect(textBlock.text).toBe('Describe what is visible on this screen.');
+  });
+
+  // =========================================================================
+  // Response Handling
+  // =========================================================================
+
+  it('returns structured description with header', async () => {
+    const result = await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('# Screen Description');
+    expect(result.content[0].text).toContain('VS Code with index.ts open');
+  });
+
+  it('includes source info for image path input', async () => {
+    const result = await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.content[0].text).toContain('image file: /test/image.png');
+  });
+
+  it('includes source info for display capture', async () => {
+    const result = await toolHandler({
+      imagePath: undefined,
+      display: 2,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.content[0].text).toContain('display 2 capture');
+  });
+
+  it('returns isError when Claude returns no text', async () => {
+    mockMessagesCreate.mockResolvedValue({ content: [] });
+
+    const result = await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No text content');
+  });
+
+  // =========================================================================
+  // Error Handling
+  // =========================================================================
+
+  it('returns isError on capture failure', async () => {
+    mockCapture.mockRejectedValue(new Error('Permission denied'));
+
+    const result = await toolHandler({
+      imagePath: undefined,
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Permission denied');
+  });
+
+  it('returns actionable error for auth failures', async () => {
+    mockMessagesCreate.mockRejectedValue(new Error('401 Unauthorized'));
+
+    const result = await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('authentication failed');
+  });
+
+  it('returns actionable error for rate limits', async () => {
+    mockMessagesCreate.mockRejectedValue(
+      new Error('429 Too Many Requests'),
+    );
+
+    const result = await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('rate limit');
+  });
+
+  it('returns generic error for unknown failures', async () => {
+    mockMessagesCreate.mockRejectedValue(new Error('Network timeout'));
+
+    const result = await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Network timeout');
+  });
+
+  // =========================================================================
+  // Temp File Cleanup
+  // =========================================================================
+
+  it('cleans up temp file after successful capture', async () => {
+    await toolHandler({
+      imagePath: undefined,
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(mockUnlink).toHaveBeenCalledWith(
+      expect.stringContaining('markupr-mcp-describe'),
+    );
+  });
+
+  it('cleans up temp file even on error', async () => {
+    mockMessagesCreate.mockRejectedValue(new Error('API error'));
+
+    await toolHandler({
+      imagePath: undefined,
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(mockUnlink).toHaveBeenCalledWith(
+      expect.stringContaining('markupr-mcp-describe'),
+    );
+  });
+
+  it('does not try to unlink when using imagePath', async () => {
+    await toolHandler({
+      imagePath: '/test/image.png',
+      display: 1,
+      apiKey: undefined,
+      focus: undefined,
+    });
+
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mcp/server.test.ts
+++ b/tests/unit/mcp/server.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests that createServer():
  * - Returns a valid McpServer instance
- * - Registers all 6 tools
+ * - Registers all 9 tools (6 core + pushToLinear + pushToGitHub + describeScreen)
  * - Registers resources
  * - Uses correct server name and version
  */
@@ -21,6 +21,9 @@ const {
   mockRegisterAnalyzeScreenshot,
   mockRegisterStartRecording,
   mockRegisterStopRecording,
+  mockRegisterPushToLinear,
+  mockRegisterPushToGitHub,
+  mockRegisterDescribeScreen,
   mockRegisterResources,
   mockTool,
   mockResource,
@@ -31,6 +34,9 @@ const {
   mockRegisterAnalyzeScreenshot: vi.fn(),
   mockRegisterStartRecording: vi.fn(),
   mockRegisterStopRecording: vi.fn(),
+  mockRegisterPushToLinear: vi.fn(),
+  mockRegisterPushToGitHub: vi.fn(),
+  mockRegisterDescribeScreen: vi.fn(),
   mockRegisterResources: vi.fn(),
   mockTool: vi.fn(),
   mockResource: vi.fn(),
@@ -60,6 +66,18 @@ vi.mock('../../../src/mcp/tools/stopRecording.js', () => ({
   register: mockRegisterStopRecording,
 }));
 
+vi.mock('../../../src/mcp/tools/pushToLinear.js', () => ({
+  register: mockRegisterPushToLinear,
+}));
+
+vi.mock('../../../src/mcp/tools/pushToGitHub.js', () => ({
+  register: mockRegisterPushToGitHub,
+}));
+
+vi.mock('../../../src/mcp/tools/describeScreen.js', () => ({
+  register: mockRegisterDescribeScreen,
+}));
+
 vi.mock('../../../src/mcp/resources/sessionResource.js', () => ({
   registerResources: mockRegisterResources,
 }));
@@ -86,7 +104,7 @@ describe('MCP Server Factory', () => {
     expect(server).toBeDefined();
   });
 
-  it('registers all 6 tool handlers', () => {
+  it('registers all 9 tool handlers', () => {
     const server = createServer();
 
     expect(mockRegisterCaptureScreenshot).toHaveBeenCalledOnce();
@@ -106,6 +124,15 @@ describe('MCP Server Factory', () => {
 
     expect(mockRegisterStopRecording).toHaveBeenCalledOnce();
     expect(mockRegisterStopRecording).toHaveBeenCalledWith(server);
+
+    expect(mockRegisterPushToLinear).toHaveBeenCalledOnce();
+    expect(mockRegisterPushToLinear).toHaveBeenCalledWith(server);
+
+    expect(mockRegisterPushToGitHub).toHaveBeenCalledOnce();
+    expect(mockRegisterPushToGitHub).toHaveBeenCalledWith(server);
+
+    expect(mockRegisterDescribeScreen).toHaveBeenCalledOnce();
+    expect(mockRegisterDescribeScreen).toHaveBeenCalledWith(server);
   });
 
   it('registers session resources', () => {


### PR DESCRIPTION
## Summary

- Adds a new `describe_screen` MCP tool that captures a screenshot (or reads an existing image path) and uses Claude's vision API to produce a structured text description of what is visible on screen
- Designed for AI coding agents that need visual context about UI state, errors, layout, and text content without receiving raw image data
- Includes 27 unit tests covering all code paths (API key resolution, capture vs path input, validation, Claude API calls, error handling, temp file cleanup)

## Version
No version bump -- this is a new tool addition to the existing MCP server, not a release.

## Testing Instructions

### Setup
- Set `ANTHROPIC_API_KEY` env var or pass via `apiKey` parameter
- The tool works in headless mode (no Electron required)

### Test Scenarios
1. **Fresh capture**: Call `describe_screen` with no `imagePath` -- should capture the screen and return a structured description
2. **Existing image**: Call with `imagePath` pointing to a screenshot -- should describe its contents
3. **Focus area**: Call with `focus: "the error dialog"` -- description should emphasize that area
4. **Missing API key**: Call without key or env var -- should return actionable error
5. **Invalid image path**: Call with nonexistent path -- should return `isError` with clear message
6. **Unit tests**: `npx vitest run tests/unit/mcp/describeScreen.test.ts tests/unit/mcp/server.test.ts` -- 32 tests pass

### Files Changed
- `src/mcp/tools/describeScreen.ts` -- New tool implementation (287 lines)
- `src/mcp/server.ts` -- Register the new tool (+2 lines)
- `tests/unit/mcp/describeScreen.test.ts` -- 27 unit tests (535 lines)
- `tests/unit/mcp/server.test.ts` -- Updated to verify all 9 tool registrations

## Checklist
- [x] Follows existing MCP tool patterns exactly
- [x] No Electron dependencies (headless mode)
- [x] Local tests pass (32/32)
- [x] Full suite passes (930/930, no regressions)
- [x] Lint clean
- [x] TypeScript type check clean
- [x] Temp files cleaned up in all code paths
- [x] Actionable error messages for common failures

Generated with [Claude Code](https://claude.com/claude-code)