### PR TITLE
feat(cli): add doctor and init commands

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,346 @@
+/**
+ * doctor.ts - Environment health check for markupr CLI
+ *
+ * Checks that all required and optional dependencies are available:
+ * - ffmpeg / ffprobe (required for video analysis)
+ * - Whisper model (optional, for local transcription)
+ * - Node.js version compatibility
+ * - Anthropic API key (optional, for AI analysis)
+ * - OpenAI API key (optional, for cloud transcription)
+ * - Disk space (for recordings and output)
+ */
+
+import { existsSync } from 'fs';
+import { stat } from 'fs/promises';
+import { execFile as execFileCb } from 'child_process';
+import { join } from 'path';
+import { homedir, platform } from 'os';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface DoctorCheck {
+  name: string;
+  status: 'pass' | 'fail' | 'warn';
+  message: string;
+  hint?: string;
+}
+
+export interface DoctorResult {
+  checks: DoctorCheck[];
+  passed: number;
+  warned: number;
+  failed: number;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Safe child environment -- only expose PATH and essential vars.
+ */
+const SAFE_CHILD_ENV = {
+  PATH: process.env.PATH,
+  HOME: process.env.HOME || process.env.USERPROFILE,
+  USERPROFILE: process.env.USERPROFILE,
+  LANG: process.env.LANG,
+};
+
+/**
+ * Execute a command and return stdout, or null on failure.
+ */
+function execQuiet(command: string, args: string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFileCb(command, args, { env: SAFE_CHILD_ENV }, (error, stdout) => {
+      if (error) {
+        resolve(null);
+      } else {
+        resolve(stdout?.toString().trim() ?? '');
+      }
+    });
+  });
+}
+
+/**
+ * Resolve the default Whisper models directory (mirrors WhisperService logic).
+ */
+function getWhisperModelsDir(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || homedir();
+  return join(home, '.markupr', 'whisper-models');
+}
+
+/**
+ * Check if any Whisper model file exists in the models directory.
+ */
+function findWhisperModel(modelsDir: string): string | null {
+  const modelNames = [
+    'ggml-tiny.bin',
+    'ggml-base.bin',
+    'ggml-small.bin',
+    'ggml-medium.bin',
+    'ggml-large-v3.bin',
+  ];
+
+  for (const name of modelNames) {
+    const modelPath = join(modelsDir, name);
+    if (existsSync(modelPath)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse a semver string into [major, minor, patch].
+ */
+function parseSemver(version: string): [number, number, number] | null {
+  const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [parseInt(match[1], 10), parseInt(match[2], 10), parseInt(match[3], 10)];
+}
+
+// ============================================================================
+// Check functions
+// ============================================================================
+
+async function checkNodeVersion(): Promise<DoctorCheck> {
+  const version = process.version; // e.g. "v20.11.0"
+  const parsed = parseSemver(version);
+
+  if (!parsed) {
+    return {
+      name: 'Node.js',
+      status: 'warn',
+      message: `Unknown version: ${version}`,
+      hint: 'markupr requires Node.js >= 18.0.0',
+    };
+  }
+
+  const [major] = parsed;
+
+  if (major >= 18) {
+    return {
+      name: 'Node.js',
+      status: 'pass',
+      message: `${version} (>= 18.0.0)`,
+    };
+  }
+
+  return {
+    name: 'Node.js',
+    status: 'fail',
+    message: `${version} is too old`,
+    hint: 'markupr requires Node.js >= 18.0.0. Upgrade at https://nodejs.org',
+  };
+}
+
+async function checkFfmpeg(): Promise<DoctorCheck> {
+  const stdout = await execQuiet('ffmpeg', ['-version']);
+
+  if (stdout === null) {
+    const os = platform();
+    const installHint =
+      os === 'darwin'
+        ? 'brew install ffmpeg'
+        : os === 'win32'
+          ? 'winget install ffmpeg (or download from https://ffmpeg.org)'
+          : 'apt install ffmpeg (or your package manager)';
+
+    return {
+      name: 'ffmpeg',
+      status: 'fail',
+      message: 'Not found on PATH',
+      hint: `Install via: ${installHint}`,
+    };
+  }
+
+  // Extract version from first line, e.g. "ffmpeg version 6.1.1 ..."
+  const versionMatch = stdout.match(/ffmpeg version (\S+)/);
+  const version = versionMatch ? versionMatch[1] : 'unknown';
+
+  return {
+    name: 'ffmpeg',
+    status: 'pass',
+    message: `Installed (${version})`,
+  };
+}
+
+async function checkFfprobe(): Promise<DoctorCheck> {
+  const stdout = await execQuiet('ffprobe', ['-version']);
+
+  if (stdout === null) {
+    return {
+      name: 'ffprobe',
+      status: 'fail',
+      message: 'Not found on PATH',
+      hint: 'ffprobe is usually installed alongside ffmpeg',
+    };
+  }
+
+  const versionMatch = stdout.match(/ffprobe version (\S+)/);
+  const version = versionMatch ? versionMatch[1] : 'unknown';
+
+  return {
+    name: 'ffprobe',
+    status: 'pass',
+    message: `Installed (${version})`,
+  };
+}
+
+async function checkWhisperModel(): Promise<DoctorCheck> {
+  const modelsDir = getWhisperModelsDir();
+
+  if (!existsSync(modelsDir)) {
+    return {
+      name: 'Whisper model',
+      status: 'warn',
+      message: 'No models directory found',
+      hint: `Models directory: ${modelsDir}\nDownload a model via the markupr desktop app, or manually place a ggml-*.bin file there`,
+    };
+  }
+
+  const model = findWhisperModel(modelsDir);
+
+  if (!model) {
+    return {
+      name: 'Whisper model',
+      status: 'warn',
+      message: 'No model files found',
+      hint: `Models directory: ${modelsDir}\nDownload a model via the markupr desktop app, or manually place a ggml-*.bin file there`,
+    };
+  }
+
+  return {
+    name: 'Whisper model',
+    status: 'pass',
+    message: `${model} found in ${modelsDir}`,
+  };
+}
+
+async function checkAnthropicKey(): Promise<DoctorCheck> {
+  const key = process.env.ANTHROPIC_API_KEY;
+
+  if (!key) {
+    return {
+      name: 'Anthropic API key',
+      status: 'warn',
+      message: 'ANTHROPIC_API_KEY not set',
+      hint: 'Optional. Set this env var to enable AI-powered analysis. Get a key at https://console.anthropic.com',
+    };
+  }
+
+  // Basic format validation (sk-ant-...)
+  if (key.startsWith('sk-ant-')) {
+    return {
+      name: 'Anthropic API key',
+      status: 'pass',
+      message: 'ANTHROPIC_API_KEY is set (sk-ant-...)',
+    };
+  }
+
+  return {
+    name: 'Anthropic API key',
+    status: 'pass',
+    message: 'ANTHROPIC_API_KEY is set',
+  };
+}
+
+async function checkOpenAIKey(): Promise<DoctorCheck> {
+  const key = process.env.OPENAI_API_KEY;
+
+  if (!key) {
+    return {
+      name: 'OpenAI API key',
+      status: 'warn',
+      message: 'OPENAI_API_KEY not set',
+      hint: 'Optional. Set this env var for cloud transcription via Whisper-1 API',
+    };
+  }
+
+  return {
+    name: 'OpenAI API key',
+    status: 'pass',
+    message: 'OPENAI_API_KEY is set',
+  };
+}
+
+async function checkDiskSpace(): Promise<DoctorCheck> {
+  // We check available space in the OS temp directory as a proxy
+  // for whether recordings/output will fit
+  try {
+    const tempDir = process.env.TMPDIR || process.env.TEMP || '/tmp';
+
+    // On most systems we cannot determine free space from stat alone.
+    // Use `df` on POSIX systems for a real check.
+    if (platform() !== 'win32') {
+      const dfOutput = await execQuiet('df', ['-k', tempDir]);
+      if (dfOutput) {
+        // Parse df output: Filesystem 1K-blocks Used Available Use% Mounted
+        const lines = dfOutput.split('\n');
+        if (lines.length >= 2) {
+          const parts = lines[1].split(/\s+/);
+          if (parts.length >= 4) {
+            const availableKB = parseInt(parts[3], 10);
+            if (!isNaN(availableKB)) {
+              const availableGB = availableKB / (1024 * 1024);
+              if (availableGB < 1) {
+                return {
+                  name: 'Disk space',
+                  status: 'warn',
+                  message: `${availableGB.toFixed(1)} GB available (low)`,
+                  hint: 'markupr recordings and output need disk space. Free up some space if you plan to record long sessions',
+                };
+              }
+              return {
+                name: 'Disk space',
+                status: 'pass',
+                message: `${availableGB.toFixed(1)} GB available`,
+              };
+            }
+          }
+        }
+      }
+    }
+
+    // Fallback: just confirm the temp dir is writable
+    await stat(tempDir);
+    return {
+      name: 'Disk space',
+      status: 'pass',
+      message: 'Temp directory accessible',
+    };
+  } catch {
+    return {
+      name: 'Disk space',
+      status: 'warn',
+      message: 'Could not determine available disk space',
+    };
+  }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Run all doctor checks and return the result.
+ */
+export async function runDoctorChecks(): Promise<DoctorResult> {
+  const checks = await Promise.all([
+    checkNodeVersion(),
+    checkFfmpeg(),
+    checkFfprobe(),
+    checkWhisperModel(),
+    checkAnthropicKey(),
+    checkOpenAIKey(),
+    checkDiskSpace(),
+  ]);
+
+  const passed = checks.filter((c) => c.status === 'pass').length;
+  const warned = checks.filter((c) => c.status === 'warn').length;
+  const failed = checks.filter((c) => c.status === 'fail').length;
+
+  return { checks, passed, warned, failed };
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,160 @@
+/**
+ * init.ts - Project initialization for markupr CLI
+ *
+ * Creates a `.markupr.json` config file in the current project directory
+ * with sensible defaults. Also adds output directory to .gitignore.
+ */
+
+import { existsSync } from 'fs';
+import { readFile, writeFile, appendFile } from 'fs/promises';
+import { join, resolve } from 'path';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface MarkuprConfig {
+  /** Directory where markupr writes feedback session output */
+  outputDir: string;
+  /** Default recording settings */
+  recording: {
+    /** Skip frame extraction by default */
+    skipFrames: boolean;
+    /** Output template name */
+    template: string;
+  };
+  /** API key references (env var names, not the actual keys) */
+  apiKeys: {
+    /** Env var name for the Anthropic API key */
+    anthropic: string;
+    /** Env var name for the OpenAI API key */
+    openai: string;
+  };
+}
+
+export interface InitOptions {
+  /** Working directory to create config in (default: cwd) */
+  directory: string;
+  /** Output directory for sessions (default: ./markupr-output) */
+  outputDir: string;
+  /** Whether to skip the .gitignore update */
+  skipGitignore: boolean;
+  /** Force overwrite existing config */
+  force: boolean;
+}
+
+export interface InitResult {
+  configPath: string;
+  created: boolean;
+  gitignoreUpdated: boolean;
+  alreadyExists: boolean;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const CONFIG_FILENAME = '.markupr.json';
+
+// ============================================================================
+// Default config
+// ============================================================================
+
+export function createDefaultConfig(outputDir: string): MarkuprConfig {
+  return {
+    outputDir,
+    recording: {
+      skipFrames: false,
+      template: 'markdown',
+    },
+    apiKeys: {
+      anthropic: 'ANTHROPIC_API_KEY',
+      openai: 'OPENAI_API_KEY',
+    },
+  };
+}
+
+// ============================================================================
+// Gitignore management
+// ============================================================================
+
+/**
+ * Add the output directory and markupr temp files to .gitignore.
+ * Returns true if the file was updated, false if entries already existed.
+ */
+export async function updateGitignore(
+  projectDir: string,
+  outputDir: string,
+): Promise<boolean> {
+  const gitignorePath = join(projectDir, '.gitignore');
+  const entriesToAdd = [outputDir, '.markupr-watch.log'];
+
+  let existingContent = '';
+  if (existsSync(gitignorePath)) {
+    existingContent = await readFile(gitignorePath, 'utf-8');
+  }
+
+  const lines = existingContent.split('\n');
+  const missingEntries = entriesToAdd.filter(
+    (entry) => !lines.some((line) => line.trim() === entry),
+  );
+
+  if (missingEntries.length === 0) {
+    return false; // Already up to date
+  }
+
+  // Build the block to append
+  const block = [
+    '',
+    '# markupr output',
+    ...missingEntries,
+    '',
+  ].join('\n');
+
+  await appendFile(gitignorePath, block, 'utf-8');
+  return true;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Initialize a markupr project configuration.
+ */
+export async function runInit(options: InitOptions): Promise<InitResult> {
+  const projectDir = resolve(options.directory);
+  const configPath = join(projectDir, CONFIG_FILENAME);
+
+  // Check if config already exists
+  if (existsSync(configPath) && !options.force) {
+    return {
+      configPath,
+      created: false,
+      gitignoreUpdated: false,
+      alreadyExists: true,
+    };
+  }
+
+  // Create config
+  const config = createDefaultConfig(options.outputDir);
+  const content = JSON.stringify(config, null, 2) + '\n';
+  await writeFile(configPath, content, 'utf-8');
+
+  // Update .gitignore
+  let gitignoreUpdated = false;
+  if (!options.skipGitignore) {
+    try {
+      gitignoreUpdated = await updateGitignore(projectDir, options.outputDir);
+    } catch {
+      // Non-critical -- don't fail init if gitignore update fails
+    }
+  }
+
+  return {
+    configPath,
+    created: true,
+    gitignoreUpdated,
+    alreadyExists: false,
+  };
+}

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Doctor Command Unit Tests
+ *
+ * Tests the environment health check functionality:
+ * - Node.js version check
+ * - ffmpeg / ffprobe availability
+ * - Whisper model detection
+ * - API key checks
+ * - Disk space check
+ * - Overall result aggregation
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Hoisted mocks
+// ============================================================================
+
+const {
+  mockExecFile,
+  mockExistsSync,
+  mockStat,
+} = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  mockExistsSync: vi.fn(),
+  mockStat: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFile: mockExecFile,
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+}));
+
+vi.mock('fs/promises', () => ({
+  stat: mockStat,
+}));
+
+vi.mock('os', () => ({
+  homedir: () => '/home/testuser',
+  platform: () => 'darwin',
+}));
+
+// ============================================================================
+// Import module under test (after mocks)
+// ============================================================================
+
+import { runDoctorChecks, type DoctorResult } from '../../src/cli/doctor';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Set up execFile mock to handle commands asynchronously.
+ */
+function mockExecFileHandler(
+  handler: (cmd: string, args: string[]) => { error: Error | null; stdout: string; stderr: string },
+) {
+  mockExecFile.mockImplementation((...callArgs: unknown[]) => {
+    const cmd = callArgs[0] as string;
+    const cmdArgs = callArgs[1] as string[];
+    const callback = callArgs[callArgs.length - 1] as (
+      err: Error | null,
+      stdout: string,
+      stderr: string,
+    ) => void;
+    const result = handler(cmd, cmdArgs);
+    process.nextTick(() => callback(result.error, result.stdout, result.stderr));
+    return { kill: vi.fn(), pid: 1 };
+  });
+}
+
+function findCheck(result: DoctorResult, name: string) {
+  return result.checks.find((c) => c.name === name);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('doctor', () => {
+  beforeEach(() => {
+    mockExecFile.mockReset();
+    mockExistsSync.mockReset();
+    mockStat.mockReset();
+    // Default: no env vars set
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  // --------------------------------------------------------------------------
+  // Node.js version
+  // --------------------------------------------------------------------------
+
+  describe('Node.js version check', () => {
+    it('passes when Node.js >= 18', async () => {
+      // process.version is read-only, but the check uses it directly.
+      // In test, Node.js is always >= 18, so this should always pass.
+      mockExecFileHandler(() => ({ error: null, stdout: '', stderr: '' }));
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'Node.js');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('pass');
+      expect(check!.message).toContain('>= 18.0.0');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // ffmpeg check
+  // --------------------------------------------------------------------------
+
+  describe('ffmpeg check', () => {
+    it('passes when ffmpeg is installed', async () => {
+      mockExecFileHandler((cmd) => {
+        if (cmd === 'ffmpeg') {
+          return { error: null, stdout: 'ffmpeg version 6.1.1 Copyright', stderr: '' };
+        }
+        if (cmd === 'ffprobe') {
+          return { error: null, stdout: 'ffprobe version 6.1.1', stderr: '' };
+        }
+        if (cmd === 'df') {
+          return { error: null, stdout: 'Filesystem 1K Used Available Use%\n/dev/disk 100000000 50000000 50000000 50% /', stderr: '' };
+        }
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'ffmpeg');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('pass');
+      expect(check!.message).toContain('6.1.1');
+    });
+
+    it('fails when ffmpeg is not installed', async () => {
+      mockExecFileHandler((cmd) => {
+        if (cmd === 'ffmpeg') {
+          return { error: new Error('ENOENT'), stdout: '', stderr: '' };
+        }
+        if (cmd === 'ffprobe') {
+          return { error: new Error('ENOENT'), stdout: '', stderr: '' };
+        }
+        if (cmd === 'df') {
+          return { error: null, stdout: 'Filesystem 1K Used Available Use%\n/dev/disk 100000000 50000000 50000000 50% /', stderr: '' };
+        }
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'ffmpeg');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('fail');
+      expect(check!.hint).toContain('brew install ffmpeg');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // ffprobe check
+  // --------------------------------------------------------------------------
+
+  describe('ffprobe check', () => {
+    it('passes when ffprobe is installed', async () => {
+      mockExecFileHandler((cmd) => {
+        if (cmd === 'ffprobe') {
+          return { error: null, stdout: 'ffprobe version 6.1.1', stderr: '' };
+        }
+        if (cmd === 'ffmpeg') {
+          return { error: null, stdout: 'ffmpeg version 6.1.1', stderr: '' };
+        }
+        if (cmd === 'df') {
+          return { error: null, stdout: 'Filesystem 1K Used Available Use%\n/dev/disk 100000000 50000000 50000000 50% /', stderr: '' };
+        }
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'ffprobe');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('pass');
+    });
+
+    it('fails when ffprobe is not installed', async () => {
+      mockExecFileHandler((cmd) => {
+        if (cmd === 'ffprobe') {
+          return { error: new Error('ENOENT'), stdout: '', stderr: '' };
+        }
+        if (cmd === 'ffmpeg') {
+          return { error: null, stdout: 'ffmpeg version 6.1.1', stderr: '' };
+        }
+        if (cmd === 'df') {
+          return { error: null, stdout: 'Filesystem 1K Used Available Use%\n/dev/disk 100000000 50000000 50000000 50% /', stderr: '' };
+        }
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'ffprobe');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('fail');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Whisper model check
+  // --------------------------------------------------------------------------
+
+  describe('Whisper model check', () => {
+    it('passes when a model file exists', async () => {
+      mockExecFileHandler((cmd) => {
+        if (cmd === 'ffmpeg') return { error: null, stdout: 'ffmpeg version 6.1.1', stderr: '' };
+        if (cmd === 'ffprobe') return { error: null, stdout: 'ffprobe version 6.1.1', stderr: '' };
+        if (cmd === 'df') return { error: null, stdout: 'Filesystem 1K Used Available Use%\n/dev/disk 100000000 50000000 50000000 50% /', stderr: '' };
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockImplementation((path: string) => {
+        // Models directory exists
+        if (path.includes('whisper-models') && !path.includes('.bin')) return true;
+        // ggml-base.bin exists
+        if (path.includes('ggml-base.bin')) return true;
+        return false;
+      });
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'Whisper model');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('pass');
+      expect(check!.message).toContain('ggml-base.bin');
+    });
+
+    it('warns when no model is found', async () => {
+      mockExecFileHandler((cmd) => {
+        if (cmd === 'ffmpeg') return { error: null, stdout: 'ffmpeg version 6.1.1', stderr: '' };
+        if (cmd === 'ffprobe') return { error: null, stdout: 'ffprobe version 6.1.1', stderr: '' };
+        if (cmd === 'df') return { error: null, stdout: 'Filesystem 1K Used Available Use%\n/dev/disk 100000000 50000000 50000000 50% /', stderr: '' };
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'Whisper model');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('warn');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // API key checks
+  // --------------------------------------------------------------------------
+
+  describe('API key checks', () => {
+    it('passes when ANTHROPIC_API_KEY is set', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+      mockExecFileHandler(() => ({ error: null, stdout: '', stderr: '' }));
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'Anthropic API key');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('pass');
+      expect(check!.message).toContain('sk-ant-');
+    });
+
+    it('warns when ANTHROPIC_API_KEY is not set', async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      mockExecFileHandler(() => ({ error: null, stdout: '', stderr: '' }));
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'Anthropic API key');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('warn');
+    });
+
+    it('passes when OPENAI_API_KEY is set', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test-openai';
+      mockExecFileHandler(() => ({ error: null, stdout: '', stderr: '' }));
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'OpenAI API key');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('pass');
+    });
+
+    it('warns when OPENAI_API_KEY is not set', async () => {
+      delete process.env.OPENAI_API_KEY;
+      mockExecFileHandler(() => ({ error: null, stdout: '', stderr: '' }));
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'OpenAI API key');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('warn');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Disk space check
+  // --------------------------------------------------------------------------
+
+  describe('disk space check', () => {
+    it('passes when sufficient disk space is available', async () => {
+      mockExecFileHandler((cmd) => {
+        if (cmd === 'df') {
+          return {
+            error: null,
+            stdout: 'Filesystem 1K-blocks Used Available Use% Mounted\n/dev/disk 100000000 50000000 50000000 50% /',
+            stderr: '',
+          };
+        }
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'Disk space');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('pass');
+      expect(check!.message).toContain('GB available');
+    });
+
+    it('warns when disk space is low', async () => {
+      mockExecFileHandler((cmd) => {
+        if (cmd === 'df') {
+          // ~500MB available (512000 KB)
+          return {
+            error: null,
+            stdout: 'Filesystem 1K-blocks Used Available Use% Mounted\n/dev/disk 100000000 99488000 512000 99% /',
+            stderr: '',
+          };
+        }
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+      const check = findCheck(result, 'Disk space');
+
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('warn');
+      expect(check!.message).toContain('low');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Result aggregation
+  // --------------------------------------------------------------------------
+
+  describe('result aggregation', () => {
+    it('counts passes, warnings, and failures correctly', async () => {
+      mockExecFileHandler((cmd) => {
+        // ffmpeg/ffprobe fail, df succeeds
+        if (cmd === 'ffmpeg') return { error: new Error('ENOENT'), stdout: '', stderr: '' };
+        if (cmd === 'ffprobe') return { error: new Error('ENOENT'), stdout: '', stderr: '' };
+        if (cmd === 'df') {
+          return {
+            error: null,
+            stdout: 'Filesystem 1K-blocks Used Available Use%\n/dev/disk 100000000 50000000 50000000 50% /',
+            stderr: '',
+          };
+        }
+        return { error: null, stdout: '', stderr: '' };
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+
+      // Should have 7 checks total
+      expect(result.checks).toHaveLength(7);
+      expect(result.passed + result.warned + result.failed).toBe(7);
+      // ffmpeg + ffprobe should fail
+      expect(result.failed).toBeGreaterThanOrEqual(2);
+    });
+
+    it('returns all 7 checks', async () => {
+      mockExecFileHandler(() => ({ error: null, stdout: '', stderr: '' }));
+      mockExistsSync.mockReturnValue(false);
+      mockStat.mockResolvedValue({});
+
+      const result = await runDoctorChecks();
+
+      const checkNames = result.checks.map((c) => c.name);
+      expect(checkNames).toContain('Node.js');
+      expect(checkNames).toContain('ffmpeg');
+      expect(checkNames).toContain('ffprobe');
+      expect(checkNames).toContain('Whisper model');
+      expect(checkNames).toContain('Anthropic API key');
+      expect(checkNames).toContain('OpenAI API key');
+      expect(checkNames).toContain('Disk space');
+    });
+  });
+});

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Init Command Unit Tests
+ *
+ * Tests the project initialization functionality:
+ * - Config file creation with defaults
+ * - Skipping when config already exists
+ * - Force overwrite
+ * - .gitignore update
+ * - Custom output directory
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Hoisted mocks
+// ============================================================================
+
+const {
+  mockExistsSync,
+  mockReadFile,
+  mockWriteFile,
+  mockAppendFile,
+} = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockWriteFile: vi.fn(),
+  mockAppendFile: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: mockReadFile,
+  writeFile: mockWriteFile,
+  appendFile: mockAppendFile,
+}));
+
+// ============================================================================
+// Import module under test (after mocks)
+// ============================================================================
+
+import {
+  runInit,
+  updateGitignore,
+  createDefaultConfig,
+  CONFIG_FILENAME,
+  type InitOptions,
+  type MarkuprConfig,
+} from '../../src/cli/init';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeInitOptions(overrides: Partial<InitOptions> = {}): InitOptions {
+  return {
+    directory: '/test/project',
+    outputDir: './markupr-output',
+    skipGitignore: false,
+    force: false,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('init', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset();
+    mockReadFile.mockReset();
+    mockWriteFile.mockReset();
+    mockAppendFile.mockReset();
+  });
+
+  // --------------------------------------------------------------------------
+  // CONFIG_FILENAME constant
+  // --------------------------------------------------------------------------
+
+  describe('CONFIG_FILENAME', () => {
+    it('is .markupr.json', () => {
+      expect(CONFIG_FILENAME).toBe('.markupr.json');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // createDefaultConfig
+  // --------------------------------------------------------------------------
+
+  describe('createDefaultConfig', () => {
+    it('returns config with correct output dir', () => {
+      const config = createDefaultConfig('./my-output');
+      expect(config.outputDir).toBe('./my-output');
+    });
+
+    it('uses markdown as default template', () => {
+      const config = createDefaultConfig('./output');
+      expect(config.recording.template).toBe('markdown');
+    });
+
+    it('does not skip frames by default', () => {
+      const config = createDefaultConfig('./output');
+      expect(config.recording.skipFrames).toBe(false);
+    });
+
+    it('references standard env var names for API keys', () => {
+      const config = createDefaultConfig('./output');
+      expect(config.apiKeys.anthropic).toBe('ANTHROPIC_API_KEY');
+      expect(config.apiKeys.openai).toBe('OPENAI_API_KEY');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // runInit - config creation
+  // --------------------------------------------------------------------------
+
+  describe('runInit', () => {
+    it('creates config file with defaults', async () => {
+      mockExistsSync.mockReturnValue(false);
+      mockWriteFile.mockResolvedValue(undefined);
+      mockAppendFile.mockResolvedValue(undefined);
+
+      const result = await runInit(makeInitOptions());
+
+      expect(result.created).toBe(true);
+      expect(result.alreadyExists).toBe(false);
+      expect(result.configPath).toContain(CONFIG_FILENAME);
+
+      // Verify writeFile was called with valid JSON
+      expect(mockWriteFile).toHaveBeenCalledTimes(1);
+      const writtenContent = mockWriteFile.mock.calls[0][1] as string;
+      const parsed = JSON.parse(writtenContent) as MarkuprConfig;
+      expect(parsed.outputDir).toBe('./markupr-output');
+      expect(parsed.recording).toBeDefined();
+      expect(parsed.apiKeys).toBeDefined();
+    });
+
+    it('skips creation when config already exists', async () => {
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path.includes(CONFIG_FILENAME)) return true;
+        return false;
+      });
+
+      const result = await runInit(makeInitOptions());
+
+      expect(result.created).toBe(false);
+      expect(result.alreadyExists).toBe(true);
+      expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it('overwrites config when --force is used', async () => {
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path.includes(CONFIG_FILENAME)) return true;
+        return false;
+      });
+      mockWriteFile.mockResolvedValue(undefined);
+      mockAppendFile.mockResolvedValue(undefined);
+
+      const result = await runInit(makeInitOptions({ force: true }));
+
+      expect(result.created).toBe(true);
+      expect(result.alreadyExists).toBe(false);
+      expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses custom output directory', async () => {
+      mockExistsSync.mockReturnValue(false);
+      mockWriteFile.mockResolvedValue(undefined);
+      mockAppendFile.mockResolvedValue(undefined);
+
+      await runInit(makeInitOptions({ outputDir: './custom-output' }));
+
+      const writtenContent = mockWriteFile.mock.calls[0][1] as string;
+      const parsed = JSON.parse(writtenContent) as MarkuprConfig;
+      expect(parsed.outputDir).toBe('./custom-output');
+    });
+
+    it('skips .gitignore when option is set', async () => {
+      mockExistsSync.mockReturnValue(false);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const result = await runInit(makeInitOptions({ skipGitignore: true }));
+
+      expect(result.gitignoreUpdated).toBe(false);
+      expect(mockAppendFile).not.toHaveBeenCalled();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // updateGitignore
+  // --------------------------------------------------------------------------
+
+  describe('updateGitignore', () => {
+    it('creates .gitignore entries when file does not exist', async () => {
+      mockExistsSync.mockReturnValue(false);
+      mockReadFile.mockResolvedValue('');
+      mockAppendFile.mockResolvedValue(undefined);
+
+      const updated = await updateGitignore('/test/project', './markupr-output');
+
+      expect(updated).toBe(true);
+      expect(mockAppendFile).toHaveBeenCalledTimes(1);
+      const appended = mockAppendFile.mock.calls[0][1] as string;
+      expect(appended).toContain('./markupr-output');
+      expect(appended).toContain('.markupr-watch.log');
+      expect(appended).toContain('# markupr output');
+    });
+
+    it('appends to existing .gitignore', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue('node_modules\n.env\n');
+      mockAppendFile.mockResolvedValue(undefined);
+
+      const updated = await updateGitignore('/test/project', './markupr-output');
+
+      expect(updated).toBe(true);
+      const appended = mockAppendFile.mock.calls[0][1] as string;
+      expect(appended).toContain('./markupr-output');
+    });
+
+    it('skips if entries already exist in .gitignore', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(
+        'node_modules\n./markupr-output\n.markupr-watch.log\n',
+      );
+
+      const updated = await updateGitignore('/test/project', './markupr-output');
+
+      expect(updated).toBe(false);
+      expect(mockAppendFile).not.toHaveBeenCalled();
+    });
+
+    it('only adds missing entries', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue('node_modules\n./markupr-output\n');
+      mockAppendFile.mockResolvedValue(undefined);
+
+      const updated = await updateGitignore('/test/project', './markupr-output');
+
+      expect(updated).toBe(true);
+      const appended = mockAppendFile.mock.calls[0][1] as string;
+      // Should only add the missing .markupr-watch.log entry
+      expect(appended).toContain('.markupr-watch.log');
+      expect(appended).not.toContain('./markupr-output');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `markupr doctor` command that checks the user's environment for all markupr dependencies (ffmpeg, ffprobe, Whisper model, Node.js version, API keys, disk space) and outputs a formatted pass/warn/fail report with actionable hints
- Add `markupr init` command that creates a `.markupr.json` config file with sensible defaults and updates `.gitignore` with markupr output entries
- Add 29 new unit tests covering both commands across `tests/unit/doctor.test.ts` and `tests/unit/init.test.ts`

## Version
No version bump (PATCH-level feature addition, can be bundled with next release)

## Testing Instructions

### Setup
No setup required -- these are zero-config commands.

### Test Scenarios
1. `markupr doctor` -- Expected: formatted environment report showing pass/warn/fail for each check
2. `markupr doctor` with ffmpeg missing -- Expected: fail status with install hint
3. `markupr init` in a project directory -- Expected: creates `.markupr.json` with defaults, updates `.gitignore`
4. `markupr init` when config already exists -- Expected: warns and exits with error (use `--force` to overwrite)
5. `markupr init --output ./custom-dir --no-gitignore` -- Expected: creates config with custom output dir, skips gitignore
6. `markupr init --force` -- Expected: overwrites existing config

### Running Tests
```bash
npx vitest run tests/unit/doctor.test.ts tests/unit/init.test.ts
```

## Checklist
- [x] Local tests pass (52/52 CLI tests)
- [x] TypeScript type check passes
- [x] CLI build succeeds
- [x] No console errors
- [x] New functionality has test coverage (29 tests)

Generated with [Claude Code](https://claude.com/claude-code)