### PR TITLE
fix: resolve 31 test failures and TypeScript error from audit

### DIFF
--- a/src/integrations/github/GitHubIssueCreator.ts
+++ b/src/integrations/github/GitHubIssueCreator.ts
@@ -402,7 +402,6 @@ export async function pushToGitHub(options: PushToGitHubOptions): Promise<PushTo
   if (dryRun) {
     // Dry run: show what would be created
     for (const item of items) {
-      const labels = getLabelsForItem(item);
       result.created.push({
         number: 0,
         url: '',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,7 +35,7 @@ import { fileURLToPath } from 'url';
 // Hide dock icon on macOS for pure menu bar experience
 // IMPORTANT: Must be called before app.whenReady()
 if (process.platform === 'darwin') {
-  app.dock.hide();
+  app.dock?.hide();
 }
 
 // Ensure runtime app identity uses the shipped product name.

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -63,27 +63,29 @@ vi.mock('crypto', () => ({
 
 // Mock shared services to avoid Electron dependencies
 vi.mock('../../src/main/pipeline/TranscriptAnalyzer', () => ({
-  TranscriptAnalyzer: vi.fn().mockImplementation(() => ({
-    analyze: vi.fn(() => []),
-  })),
+  TranscriptAnalyzer: vi.fn().mockImplementation(function () {
+    return { analyze: vi.fn(() => []) };
+  }),
 }));
 
 vi.mock('../../src/main/pipeline/FrameExtractor', () => ({
-  FrameExtractor: vi.fn().mockImplementation(() => ({
-    checkFfmpeg: vi.fn(() => Promise.resolve(true)),
-    extract: vi.fn(() => Promise.resolve({ frames: [] })),
-  })),
+  FrameExtractor: vi.fn().mockImplementation(function () {
+    return {
+      checkFfmpeg: vi.fn(() => Promise.resolve(true)),
+      extract: vi.fn(() => Promise.resolve({ frames: [] })),
+    };
+  }),
 }));
 
 vi.mock('../../src/main/output/MarkdownGenerator', () => ({
-  MarkdownGenerator: vi.fn().mockImplementation(() => ({
-    generateFromPostProcess: vi.fn(() => '# Test Markdown'),
-  })),
+  MarkdownGenerator: vi.fn().mockImplementation(function () {
+    return { generateFromPostProcess: vi.fn(() => '# Test Markdown') };
+  }),
 }));
 
 vi.mock('../../src/main/transcription/WhisperService', () => {
   return {
-    WhisperService: vi.fn().mockImplementation(() => {
+    WhisperService: vi.fn().mockImplementation(function () {
       const emitter = new EventEmitter();
       return Object.assign(emitter, {
         isModelAvailable: vi.fn(() => false),

--- a/tests/unit/cli/watchMode.test.ts
+++ b/tests/unit/cli/watchMode.test.ts
@@ -52,10 +52,9 @@ const mockPipelineRun = vi.fn();
 const mockPipelineAbort = vi.fn();
 
 vi.mock('../../../src/cli/CLIPipeline', () => ({
-  CLIPipeline: vi.fn().mockImplementation(() => ({
-    run: mockPipelineRun,
-    abort: mockPipelineAbort,
-  })),
+  CLIPipeline: vi.fn().mockImplementation(function () {
+    return { run: mockPipelineRun, abort: mockPipelineAbort };
+  }),
 }));
 
 // ============================================================================

--- a/tests/unit/integrations/linear/pushToLinear.test.ts
+++ b/tests/unit/integrations/linear/pushToLinear.test.ts
@@ -27,9 +27,9 @@ vi.mock('fs/promises', () => ({
 }));
 
 vi.mock('../../../../src/integrations/linear/LinearIssueCreator.js', () => ({
-  LinearIssueCreator: vi.fn().mockImplementation(() => ({
-    pushReport: mockPushReport,
-  })),
+  LinearIssueCreator: vi.fn().mockImplementation(function () {
+    return { pushReport: mockPushReport };
+  }),
 }));
 
 vi.mock('../../../../src/mcp/utils/Logger.js', () => ({

--- a/tests/unit/mcp/analyzeVideo.test.ts
+++ b/tests/unit/mcp/analyzeVideo.test.ts
@@ -31,7 +31,7 @@ const {
   return {
     mockStat: vi.fn(),
     mockPipelineRun: pipelineRun,
-    mockCLIPipeline: vi.fn().mockImplementation(() => ({ run: pipelineRun })),
+    mockCLIPipeline: vi.fn().mockImplementation(function () { return { run: pipelineRun }; }),
     mockCreate: vi.fn(),
     mockGetSessionDir: vi.fn(),
     mockUpdate: vi.fn(),

--- a/tests/unit/mcp/captureWithVoice.test.ts
+++ b/tests/unit/mcp/captureWithVoice.test.ts
@@ -28,7 +28,7 @@ const {
   return {
     mockRecord: vi.fn(),
     mockPipelineRun: pipelineRun,
-    mockCLIPipeline: vi.fn().mockImplementation(() => ({ run: pipelineRun })),
+    mockCLIPipeline: vi.fn().mockImplementation(function () { return { run: pipelineRun }; }),
     mockCreate: vi.fn(),
     mockGetSessionDir: vi.fn(),
     mockUpdate: vi.fn(),

--- a/tests/unit/mcp/server.test.ts
+++ b/tests/unit/mcp/server.test.ts
@@ -65,13 +65,15 @@ vi.mock('../../../src/mcp/resources/sessionResource.js', () => ({
 }));
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
-  McpServer: vi.fn().mockImplementation((config: { name: string; version: string }) => ({
-    name: config.name,
-    version: config.version,
-    tool: mockTool,
-    resource: mockResource,
-    connect: vi.fn(),
-  })),
+  McpServer: vi.fn().mockImplementation(function (config: { name: string; version: string }) {
+    return {
+      name: config.name,
+      version: config.version,
+      tool: mockTool,
+      resource: mockResource,
+      connect: vi.fn(),
+    };
+  }),
 }));
 
 import { createServer } from '../../../src/mcp/server.js';

--- a/tests/unit/mcp/stopRecording.test.ts
+++ b/tests/unit/mcp/stopRecording.test.ts
@@ -32,7 +32,7 @@ const {
   return {
     mockStop: vi.fn(),
     mockPipelineRun: pipelineRun,
-    mockCLIPipeline: vi.fn().mockImplementation(() => ({ run: pipelineRun })),
+    mockCLIPipeline: vi.fn().mockImplementation(function () { return { run: pipelineRun }; }),
     mockIsRecording: vi.fn(),
     mockGetCurrent: vi.fn(),
     mockActiveStop: vi.fn(),

--- a/tests/unit/tierManager.test.ts
+++ b/tests/unit/tierManager.test.ts
@@ -1,4 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
+
+// Mock dependencies that pull in electron-store
+vi.mock('../../src/main/settings', () => ({
+  getSettingsManager: vi.fn().mockReturnValue({
+    get: vi.fn().mockReturnValue({}),
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/main/transcription/ModelDownloadManager', () => ({
+  modelDownloadManager: {
+    hasAnyModel: vi.fn().mockReturnValue(false),
+    getDefaultModel: vi.fn().mockReturnValue(null),
+    getModelPath: vi.fn().mockReturnValue(null),
+  },
+}));
+
 import { TierManager } from '../../src/main/transcription/TierManager';
 import type { TierStatus } from '../../src/main/transcription/types';
 

--- a/tests/unit/tierManagerExpanded.test.ts
+++ b/tests/unit/tierManagerExpanded.test.ts
@@ -10,6 +10,23 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+
+// Mock dependencies that pull in electron-store
+vi.mock('../../src/main/settings', () => ({
+  getSettingsManager: vi.fn().mockReturnValue({
+    get: vi.fn().mockReturnValue({}),
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/main/transcription/ModelDownloadManager', () => ({
+  modelDownloadManager: {
+    hasAnyModel: vi.fn().mockReturnValue(false),
+    getDefaultModel: vi.fn().mockReturnValue(null),
+    getModelPath: vi.fn().mockReturnValue(null),
+  },
+}));
+
 import { TierManager } from '../../src/main/transcription/TierManager';
 import type { TierStatus } from '../../src/main/transcription/types';
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,10 +37,6 @@ export default defineConfig({
     reporters: ['default'],
     // Pool settings for better isolation
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    isolate: true,
   },
 });


### PR DESCRIPTION
## Summary

- Fix **31 test failures** caused by Vitest v4 mock incompatibility — arrow functions in `vi.fn().mockImplementation()` can't be used as constructors; switched to regular functions
- Add missing `electron-store` mocks to `tierManager.test.ts` and `tierManagerExpanded.test.ts`
- Fix TypeScript error `TS18048`: `app.dock?.hide()` optional chaining in `src/main/index.ts`
- Remove unused `labels` variable in `GitHubIssueCreator.ts` dry-run path (lint warning)
- Migrate deprecated `poolOptions` to top-level `isolate` in `vitest.config.ts`

## Results

| Metric | Before | After |
|--------|--------|-------|
| Tests | 815 pass / 31 fail | **860 pass / 0 fail** |
| Typecheck | 1 error | **0 errors** |
| Lint warnings | 6 | **5** (removed new one, 5 pre-existing) |
| Build | Pass | **Pass** |

## Test plan

- [x] All 860 tests pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (0 errors)
- [x] Build succeeds (desktop + CLI + MCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)