### PR TITLE
chore: bump version to v2.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ As of v2.5.0, markupr also ships as:
 - **MCP server** (`npx markupr-mcp`) -- Model Context Protocol server for AI coding agents (capture screenshots, analyze video, start/stop recordings)
 - **GitHub Action** (`eddiesanjuan/markupr-action@v1`) -- CI/CD visual feedback on PRs
 
-**Version:** 2.5.0
+**Version:** 2.6.0
 **License:** MIT (Open Source)
 
 ## Tech Stack
@@ -67,7 +67,10 @@ src/
 │   └── windows/            # Window management (popover, taskbar)
 ├── cli/                    # Headless CLI tool
 │   ├── index.ts            # CLI entry point (commander-based)
-│   └── CLIPipeline.ts      # Video analysis pipeline (ffmpeg + Whisper + markdown)
+│   ├── CLIPipeline.ts      # Video analysis pipeline (ffmpeg + Whisper + markdown)
+│   ├── WatchMode.ts        # Watch directory for new recordings
+│   ├── doctor.ts           # System dependency checker (ffmpeg, Whisper, etc.)
+│   └── init.ts             # Project config scaffolding (.markupr.json)
 ├── mcp/                    # MCP server for AI coding agents
 │   ├── index.ts            # MCP entry point
 │   ├── server.ts           # MCP server setup
@@ -76,6 +79,9 @@ src/
 │   │   ├── analyzeVideo.ts       # Analyze a video recording
 │   │   ├── captureScreenshot.ts  # Capture a screenshot
 │   │   ├── captureWithVoice.ts   # Capture with voice narration
+│   │   ├── describeScreen.ts     # AI agents can see the user's screen
+│   │   ├── pushToGitHub.ts       # Push feedback to GitHub Issues
+│   │   ├── pushToLinear.ts       # Push feedback to Linear
 │   │   ├── startRecording.ts     # Start a recording session
 │   │   └── stopRecording.ts      # Stop a recording session
 │   ├── session/            # MCP session management

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markupr",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markupr",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markupr",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Record your screen, narrate feedback, get structured Markdown with screenshots. Desktop app, CLI, and MCP server for AI coding agents like Claude Code, Cursor, and Windsurf.",
   "type": "module",
   "main": "dist/main/index.mjs",


### PR DESCRIPTION
## Summary

Version bump from v2.5.0 to v2.6.0 covering all changes merged since the last release.

## New in v2.6.0

- **MCP `describe_screen` tool** -- AI agents can now see the user's screen for visual context (PR #43)
- **CLI `doctor` and `init` commands** -- system dependency checker and project config scaffolding (PR #45)
- **Software Update section in Settings** -- check for updates button, auto-update toggle, local build fallback (PR #41)
- **Test suite expanded** -- 887 to 1,025 tests across 54 files (PR #44)
- **README rewrite** -- world-class README with architecture diagrams (PR #42)

## Changes in this PR

- `package.json`: version `2.5.0` -> `2.6.0`
- `package-lock.json`: synced
- `CLAUDE.md`: updated version, added new CLI files (`doctor.ts`, `init.ts`, `WatchMode.ts`) and MCP tools (`describeScreen.ts`, `pushToGitHub.ts`, `pushToLinear.ts`) to architecture tree

## Version

2.5.0 -> 2.6.0 (MINOR)

## Checklist

- [x] Version bumped in package.json
- [x] package-lock.json synced
- [x] CLAUDE.md version updated
- [x] CLAUDE.md architecture tree updated with new files
- [x] All 1,025 tests pass
- [x] TypeScript type checking passes
- [x] No functional code changes